### PR TITLE
Typo fix for module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In ``settings.py`` add to:
 ```python
 INSTALLED_APPS = (
     ...
-    'sass_processors',
+    'sass_processor',
     ...
 )
 ```


### PR DESCRIPTION
When running django server ImportError occurs because module name is 'sass_processor' instead of 'sass_processors'.