### PR TITLE
Add support for jade templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Mac
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ reverse the above command:
 
 This will remove all occurrences of previously generated ``*.css`` files.
 
+By default, **django-sass-processor** will locate SASS/SCSS files from .html and .jade templates,
+but you can extend or override this behavior. Just use the following syntax in ``settings.py``: 
+
+```
+SASS_TEMPLATE_EXTS = ['.html,'.jade']
+```
+
 
 ## Configure SASS variables through settings.py
 

--- a/sass_processor/management/commands/compilescss.py
+++ b/sass_processor/management/commands/compilescss.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
 
     def __init__(self):
         self.parser = DjangoParser(charset=settings.FILE_CHARSET)
-        self.template_exts = getattr(settings, 'SASS_TEMPLATE_EXTS', ['.html'])
+        self.template_exts = getattr(settings, 'SASS_TEMPLATE_EXTS', ['.html','.jade'])
         self.output_style = getattr(settings, 'SASS_OUTPUT_STYLE', 'compact')
         super(Command, self).__init__()
 


### PR DESCRIPTION
I was wondering why `./manage.py compilescss` wasn't detecting any of my SCSS files, until I found that line and realized the template I was testing was in jade :-) . I have done limited testing (only two SCSS files, one `@import`ed by the other), and this worked fine so far.

Edit: Beside changing the default, I realized it may also be interesting to mention `SASS_TEMPLATE_EXTS` in the README, I added an additional commit for that purpose.