### PR TITLE
Describe 0.3.0 changes and add Python 3 compatibility classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ from you HTML templates.
 
 ## Changelog
 
+* 0.3.0
+ - Compatible with Django 1.8+.
+ - bootstrap3-sass ready: appropriate floating point precision (8) can be set in ``settings.py``.
+ - Offline compilation results may optionally be stored in ``SASS_PROCESSOR_ROOT``.
+
 * 0.2.6
  - Hotfix: added SASS function ``get-setting`` also to offline compiler.
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ CLASSIFIERS = [
     'Programming Language :: Python',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Programming Language :: Python :: 2.7',
-    # not tested: 'Programming Language :: Python :: 3.3',
+    'Programming Language :: Python :: 3',
 ]
 
 


### PR DESCRIPTION
Follow up to https://github.com/jrief/django-sass-processor/pull/13.

Tested in online and offline compilation on Python 3.4 and Django 1.8 with bootstrap3-sass - ok.
I think both open issues ([11](https://github.com/jrief/django-sass-processor/issues/11), [10](https://github.com/jrief/django-sass-processor/issues/11)) may be closed now.

