### PR TITLE
Force save compiled and map files in UTF-8

### DIFF
--- a/sass_processor/templatetags/sass_tags.py
+++ b/sass_processor/templatetags/sass_tags.py
@@ -10,7 +10,7 @@ from django.core.files.base import ContentFile
 from django.core.exceptions import ImproperlyConfigured
 from django.template import Library, Context
 from django.template.base import Node, TemplateSyntaxError
-from django.utils.encoding import iri_to_uri
+from django.utils.encoding import iri_to_uri, force_bytes
 from django.utils.six.moves.urllib.parse import urljoin
 from sass_processor.utils import get_setting
 from ..storage import SassFileStorage, find_file
@@ -105,6 +105,8 @@ class SassSrcNode(Node):
         if self.sass_output_style:
             compile_kwargs['output_style'] = self.sass_output_style
         content, sourcemap = sass.compile(**compile_kwargs)
+        content = force_bytes(content)
+        sourcemap = force_bytes(sourcemap)
         if self.storage.exists(css_filename):
             self.storage.delete(css_filename)
         self.storage.save(css_filename, ContentFile(content))


### PR DESCRIPTION
If you have non-ascii symbols in your scss, and your system locale differ from UTF-8 (say, non-english Windows), online compilation save compiled files with system codepage (windows-1251, in my case).