### PR TITLE
Fix compilescss for Django 1.9.2

### DIFF
--- a/sass_processor/management/commands/compilescss.py
+++ b/sass_processor/management/commands/compilescss.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
                 module = import_module(loader.__module__)
                 get_template_sources = getattr(module, 'get_template_sources', loader.get_template_sources)
                 template_sources = list(get_template_sources(''))
-                if template_sources and type(template_sources[0]) is Origin:
+                if template_sources and isinstance(template_sources[0], Origin):
                     template_sources = [origin.name for origin in template_sources]
                 paths.update(template_sources)
             except (ImportError, AttributeError):

--- a/sass_processor/management/commands/compilescss.py
+++ b/sass_processor/management/commands/compilescss.py
@@ -5,7 +5,8 @@ import sass
 from optparse import make_option
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.template.loader import get_template, Origin  # noqa Leave get_template in to preload template locations
+from django.template.base import Origin
+from django.template.loader import get_template  # noqa Leave this in to preload template locations
 from importlib import import_module
 from django.utils.encoding import force_bytes
 from compressor.exceptions import TemplateDoesNotExist, TemplateSyntaxError

--- a/sass_processor/management/commands/compilescss.py
+++ b/sass_processor/management/commands/compilescss.py
@@ -5,7 +5,7 @@ import sass
 from optparse import make_option
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.template.loader import get_template  # noqa Leave this in to preload template locations
+from django.template.loader import get_template, Origin  # noqa Leave get_template in to preload template locations
 from importlib import import_module
 from django.utils.encoding import force_bytes
 from compressor.exceptions import TemplateDoesNotExist, TemplateSyntaxError
@@ -84,7 +84,10 @@ class Command(BaseCommand):
             try:
                 module = import_module(loader.__module__)
                 get_template_sources = getattr(module, 'get_template_sources', loader.get_template_sources)
-                paths.update(list(get_template_sources('')))
+                template_sources = list(get_template_sources(''))
+                if template_sources and type(template_sources[0]) is Origin:
+                    template_sources = [origin.name for origin in template_sources]
+                paths.update(template_sources)
             except (ImportError, AttributeError):
                 pass
         if not paths:


### PR DESCRIPTION
Django 1.9.2 now returns `django.template.Origin` objects from the `django.template.loaders.base.Loader.get_template_sources` method, breaking the `compilescss` command, which assumes that the method returns strings. This pull request fixes this problem.