### PR TITLE
Version 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,20 +77,21 @@ SASS_PROCESSOR_INCLUDE_DIRS = (
 
 Additionally, **django-sass-processor** will traverse all installed Django apps and look into their
 static folders. If any of them contain a file starting with a ``_`` (underscore) and ending in
-``.scss`` or ``.sass``, then that app specific static folder is added to the include paths.
+``.scss`` or ``.sass``, then that app specific static folder is added to the **libsass** include
+dirs. This feature can be disabled by setting ``SASS_PROCESSOR_AUTO_INCLUDE = False``.
 
-During development, or when ``SASS_PROCESSOR_ENABLED`` is set to ``True``, the compiled file is
-placed into the folder referenced by ``SASS_PROCESSOR_ROOT`` (if unset, this setting defaults to
-``STATIC_ROOT``). Having a location outside of the working directory prevents to pollute your local
-``static/css/...`` folders with auto-generated files. Therefore assure, that this directory is
-writable by the Django runserver.
+During development, or when ``SASS_PROCESSOR_ENABLED == True``, the compiled file is placed into the
+folder referenced by ``SASS_PROCESSOR_ROOT`` (if unset, this setting defaults to ``STATIC_ROOT``).
+Having a location outside of the working directory prevents to pollute your local ``static/css/...``
+folders with auto-generated files. Therefore assure, that this directory is writable by the Django
+runserver.
 
 **django-sass-processor** is shipped with a special finder, to locate the generated ``*.css`` files
 in the folder referred by ``SASS_PROCESSOR_ROOT`` (or, if unset ``STATIC_ROOT``). Just add it to
-your ``settings.py``. If there is no ``STATICFILES_FINDERS`` setting in your ``settings.py`` don't
-forget to include **django** [default finders](https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-STATICFILES_FINDERS).
+your ``settings.py``. If there is no ``STATICFILES_FINDERS`` in your ``settings.py`` don't forget
+to include the **Django** [default finders](https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-STATICFILES_FINDERS).
 
-```
+```python
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
@@ -99,7 +100,7 @@ STATICFILES_FINDERS = (
 )
 ```
 
-You may fine tune sass compiler parameters in your `settings.py`.
+#### Fine tune SASS compiler parameters in ``settings.py``.
 
 Integer `SASS_PRECISION` sets floating point precision for output css. libsass'
 default is ``5``. Note: **bootstrap-sass** requires ``8``, otherwise various
@@ -188,7 +189,7 @@ class SomeAdminOrFormClass(...):
         }
 ```
 
-This feature is available since version 0.4.0.
+Please note that ``*.scss``/``.sass`` files using this function can not be compiled offline.
 
 
 ## Offline compilation
@@ -226,6 +227,9 @@ If you use an alternative templating engine (django 1.8+) set its name in ``--en
 ``django`` and ``jinja2`` is supported, see
 [django-compressor documentation](http://django-compressor.readthedocs.org/en/latest/) on how to
 set up ``COMPRESS_JINJA2_GET_ENVIRONMENT`` to configure jinja2 engine support.
+
+Please note that offline compilation only applies to ``*.scss``/``.sass`` files referenced in
+templates, but not in Python modules using ``sass_processor``.
 
 
 ### Alternative templates
@@ -272,8 +276,8 @@ value. For the Glyphicons font search path, add this to your ``_variables.scss``
 $icon-font-path: unquote(get-setting(NODE_MODULES_URL) + "bootstrap-sass/assets/fonts/bootstrap/");
 ```
 
-and ``@import "variables";`` whenever you need Glyphicons. You then can safely remove any
-font references, such as ``<link href="/path/to/your/fonts/bootstrap/glyphicons-whatever.ttf" ...>``
+and ``@import "variables";`` whenever you need Glyphicons. You then can safely remove any font
+references, such as ``<link href="/path/to/your/fonts/bootstrap/glyphicons-whatever.ttf" ...>``
 from you HTML templates.
 
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,14 @@ Optionally, add a list of additional search paths, the SASS compiler may examine
 import os
 
 SASS_PROCESSOR_INCLUDE_DIRS = (
-    os.path.join(PROJECT_PATH, 'mystyles/scss'),
+    os.path.join(PROJECT_PATH, 'extra-styles/scss'),
     os.path.join(PROJECT_PATH, 'node_modules'),
 )
 ```
+
+Additionally, **django-sass-processor** will traverse all installed Django apps and look into their
+static folders. If any of them contain a file starting with a ``_`` (underscore) and ending in
+``.scss`` or ``.sass``, then that app specific static folder is added to the include paths.
 
 During development, or when ``SASS_PROCESSOR_ENABLED`` is set to ``True``, the compiled file is
 placed into the folder referenced by ``SASS_PROCESSOR_ROOT`` (if unset, this setting defaults to

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ and deployed using offline compilation.
 In ``settings.py`` add to:
 
 ```python
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     ...
     'sass_processor',
     ...
-)
+]
 ```
 
 Optionally, add a list of additional search paths, the SASS compiler may examine when using the
@@ -69,10 +69,10 @@ Optionally, add a list of additional search paths, the SASS compiler may examine
 ```python
 import os
 
-SASS_PROCESSOR_INCLUDE_DIRS = (
+SASS_PROCESSOR_INCLUDE_DIRS = [
     os.path.join(PROJECT_PATH, 'extra-styles/scss'),
     os.path.join(PROJECT_PATH, 'node_modules'),
-)
+]
 ```
 
 Additionally, **django-sass-processor** will traverse all installed Django apps and look into their
@@ -80,24 +80,24 @@ static folders. If any of them contain a file starting with a ``_`` (underscore)
 ``.scss`` or ``.sass``, then that app specific static folder is added to the **libsass** include
 dirs. This feature can be disabled by setting ``SASS_PROCESSOR_AUTO_INCLUDE = False``.
 
-During development, or when ``SASS_PROCESSOR_ENABLED == True``, the compiled file is placed into the
+During development, or when ``SASS_PROCESSOR_ENABLED = True``, the compiled file is placed into the
 folder referenced by ``SASS_PROCESSOR_ROOT`` (if unset, this setting defaults to ``STATIC_ROOT``).
 Having a location outside of the working directory prevents to pollute your local ``static/css/...``
-folders with auto-generated files. Therefore assure, that this directory is writable by the Django
-runserver.
+directories with auto-generated files. Therefore assure, that this directory is writable by the
+Django runserver.
 
 **django-sass-processor** is shipped with a special finder, to locate the generated ``*.css`` files
-in the folder referred by ``SASS_PROCESSOR_ROOT`` (or, if unset ``STATIC_ROOT``). Just add it to
+in the directory referred by ``SASS_PROCESSOR_ROOT`` (or, if unset ``STATIC_ROOT``). Just add it to
 your ``settings.py``. If there is no ``STATICFILES_FINDERS`` in your ``settings.py`` don't forget
 to include the **Django** [default finders](https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-STATICFILES_FINDERS).
 
 ```python
-STATICFILES_FINDERS = (
+STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'sass_processor.finders.CssFinder',
     ...
-)
+]
 ```
 
 #### Fine tune SASS compiler parameters in ``settings.py``.
@@ -177,9 +177,7 @@ In Python code, you can access the API of the SASS processor directly. This for 
 in Django's admin or form framework.
 
 ```python
-from sass_processor.processor import SassProcessor
-
-sass_processor = SassProcessor()
+from sass_processor.processor import sass_processor
 
 class SomeAdminOrFormClass(...):
     ...
@@ -188,8 +186,6 @@ class SomeAdminOrFormClass(...):
             'all': (sass_processor('myapp/css/mystyle.scss'),)
         }
 ```
-
-Please note that ``*.scss``/``.sass`` files using this function can not be compiled offline.
 
 
 ## Offline compilation
@@ -228,8 +224,9 @@ If you use an alternative templating engine (django 1.8+) set its name in ``--en
 [django-compressor documentation](http://django-compressor.readthedocs.org/en/latest/) on how to
 set up ``COMPRESS_JINJA2_GET_ENVIRONMENT`` to configure jinja2 engine support.
 
-Please note that offline compilation only applies to ``*.scss``/``.sass`` files referenced in
-templates, but not in Python modules using ``sass_processor``.
+During offline compilation **django-sass-processor** parses all Python files and looks for
+invokations of ``sass_processor('path/to/sassfile.scss')``. Therefore the string specifying
+the filename must be hard coded and shall not be concatenated or being somehow generated.
 
 
 ### Alternative templates
@@ -237,7 +234,7 @@ templates, but not in Python modules using ``sass_processor``.
 By default, **django-sass-processor** will locate SASS/SCSS files from .html templates,
 but you can extend or override this behavior. Just use the following syntax in ``settings.py``:
 
-```
+```python
 SASS_TEMPLATE_EXTS = ['.html','.jade']
 ```
 
@@ -250,20 +247,20 @@ done through a ``_variables.scss`` file, but this inhibits a configuration throu
 
 To avoid the need for duplicate configuration settings, **django-sass-processor** offers a SASS
 function to fetch any arbitrary configuration from the project's ``settings.py``. This is specially
-handy for setting the include path of your Glyphicons font directory. Assume you installed Bootstrap
-SASS files using
+handy for setting the include path of your Glyphicons font directory. Assume, Bootstrap-SASS has
+been installed using:
 
 ```npm install bootstrap-sass```
 
 then locate your ``node_modules`` folder and add it to your ``settings.py``, so that your fonts are
 accessible through the Django's ``django.contrib.staticfiles.finders.FileSystemFinder``:
 
-```
-STATICFILES_DIRS = (
+```python
+STATICFILES_DIRS = [
     ...
     ('node_modules', '/path/to/your/project/node_modules/'),
     ...
-)
+]
 
 NODE_MODULES_URL = STATIC_URL + 'node_modules/'
 
@@ -282,6 +279,10 @@ from you HTML templates.
 
 
 ## Changelog
+
+* 0.5.0
+- SASS/SCSS files can also be referenced in pure Python files, for instance in ``Media`` class or
+  ``media`` property definitions.
 
 * 0.4.0 - 0.4.4
 - Refactored the sass processor into a self-contained class ``SassProcessor``, which can be accessed

--- a/README.md
+++ b/README.md
@@ -75,10 +75,27 @@ SASS_PROCESSOR_INCLUDE_DIRS = [
 ]
 ```
 
-Additionally, **django-sass-processor** will traverse all installed Django apps and look into their
-static folders. If any of them contain a file starting with a ``_`` (underscore) and ending in
-``.scss`` or ``.sass``, then that app specific static folder is added to the **libsass** include
-dirs. This feature can be disabled by setting ``SASS_PROCESSOR_AUTO_INCLUDE = False``.
+Additionally, **django-sass-processor** will traverse all installed Django apps (``INSTALLED_APPS``)
+and look into their static folders. If any of them contain a file matching the regular expression
+pattern ``^_.+\.(scss|sass)$`` (read: filename starts with an underscore and is of type ``scss`` or
+``sass``), then that app specific static folder is added to the **libsass** include dirs. This
+feature can be disabled in your settings with
+
+```python
+SASS_PROCESSOR_AUTO_INCLUDE = False
+```
+
+If inside of your SASS/SCSS files you also want to import (using ``@import "path/to/scssfile";``)
+files which do not start with an underscore, then you can configure another pattern in your
+settings, for instance
+
+```python
+SASS_PROCESSOR_INCLUDE_FILE_PATTERN = r'^.+\.scss$'
+```
+
+will look for all files of type ``scss``. Remember that SASS/SCSS files which start with an
+underscore are intended to be imported by other SASS/SCSS files, while files starting with a letter
+are intended to be included by the HTML tag ``<link href="{% sass_src 'path/to/file' %}" ...>``.
 
 During development, or when ``SASS_PROCESSOR_ENABLED = True``, the compiled file is placed into the
 folder referenced by ``SASS_PROCESSOR_ROOT`` (if unset, this setting defaults to ``STATIC_ROOT``).
@@ -127,25 +144,23 @@ SASS_OUTPUT_STYLE = 'compact'
 
 In `settings.py`:
 ```python
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.jinja2.Jinja2',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'environment': 'yourapp.jinja2.environment'
-        }
-    }
-]
+TEMPLATES = [{
+    'BACKEND': 'django.template.backends.jinja2.Jinja2',
+    'DIRS': [],
+    'APP_DIRS': True,
+    'OPTIONS': {
+        'environment': 'yourapp.jinja2.environment'
+    },
+    ...
+}]
 ```
 
-Make sure to still add the default template backend if you're still using Django templates elsewhere.
-This is covered in the [upgrading to 1.8 documentation](https://docs.djangoproject.com/en/1.9/ref/templates/upgrading/).
+Make sure to add the default template backend, if you're still using Django templates elsewhere.
+This is covered in the [Upgrading templates documentation](https://docs.djangoproject.com/en/stable/ref/templates/upgrading/).
 
 In `yourapp/jinja2.py`:
 ```python
 from jinja2 import Environment
-
 
 def environment(**kwargs):
     extensions = [] if 'extensions' not in kwargs else kwargs['extensions']
@@ -159,14 +174,17 @@ def environment(**kwargs):
 
 ### In your Django templates
 
-```html
+```django
 {% load sass_tags %}
 
 <link href="{% sass_src 'myapp/css/mystyle.scss' %}" rel="stylesheet" type="text/css" />
 ```
 
-The above template code will be render as HTML such as
-``<link href="/static/myapp/css/mystyle.css" rel="stylesheet" type="text/css" />``
+The above template code will be rendered as HTML
+
+```html
+<link href="/static/myapp/css/mystyle.css" rel="stylesheet" type="text/css" />
+```
 
 You can safely use this templatetag inside a Sekizai's ``{% addtoblock "css" %}`` statement.
 
@@ -192,20 +210,27 @@ class SomeAdminOrFormClass(...):
 
 If you want to precompile all occurrences of your SASS/SCSS files for the whole project, on the
 command line invoke:
-
 ```
 ./manage.py compilescss
 ```
-
 This is useful for preparing production environments, where SASS/SCSS files can't be compiled on
-the fly. To simplify the deployment, the compiled ``*.css`` files are stored side-by-side with their
-corresponding SASS/SCSS files; just run ``./manage.py collectstatic`` afterwards. In case you
-don't want to expose the SASS/SCSS files in a production environment, deploy with
-``./manage.py collectstatic --ignore=.scss``.
+the fly.
+
+To simplify the deployment, the compiled ``*.css`` files are stored side-by-side with their
+corresponding SASS/SCSS files; just run
+```
+./manage.py collectstatic
+```
+afterwards.
+
+In case you don't want to expose the SASS/SCSS files in a production environment,
+deploy with
+```
+./manage.py collectstatic --ignore=.scss
+```
 
 In case you want to get rid of the compiled ``*.css`` files in your local static directories, simply
 reverse the above command:
-
 ```
 ./manage.py compilescss --delete-files
 ```
@@ -213,14 +238,13 @@ This will remove all occurrences of previously generated ``*.css`` files.
 
 Or you may direct compile results to the ``SASS_PROCESSOR_ROOT`` directory (if not specified - to
 ``STATIC_ROOT``):
-
 ```
 ./manage.py compilescss --use-processor-root
 ```
 Combine with ``--delete-files`` switch to purge results from there.
 
-If you use an alternative templating engine (django 1.8+) set its name in ``--engine`` argument.
-``django`` and ``jinja2`` is supported, see
+If you use an alternative templating engine set its name in ``--engine`` argument. Currently
+``django`` and ``jinja2`` are supported, see
 [django-compressor documentation](http://django-compressor.readthedocs.org/en/latest/) on how to
 set up ``COMPRESS_JINJA2_GET_ENVIRONMENT`` to configure jinja2 engine support.
 
@@ -232,12 +256,10 @@ the filename must be hard coded and shall not be concatenated or being somehow g
 ### Alternative templates
 
 By default, **django-sass-processor** will locate SASS/SCSS files from .html templates,
-but you can extend or override this behavior. Just use the following syntax in ``settings.py``:
-
+but you can extend or override this behavior in your settings with:
 ```python
 SASS_TEMPLATE_EXTS = ['.html','.jade']
 ```
-
 
 ## Configure SASS variables through settings.py
 
@@ -249,10 +271,11 @@ To avoid the need for duplicate configuration settings, **django-sass-processor*
 function to fetch any arbitrary configuration from the project's ``settings.py``. This is specially
 handy for setting the include path of your Glyphicons font directory. Assume, Bootstrap-SASS has
 been installed using:
+```
+npm install bootstrap-sass
+```
 
-```npm install bootstrap-sass```
-
-then locate your ``node_modules`` folder and add it to your ``settings.py``, so that your fonts are
+then locate the directory named ``node_modules`` and add it to your settings, so that your fonts are
 accessible through the Django's ``django.contrib.staticfiles.finders.FileSystemFinder``:
 
 ```python
@@ -263,7 +286,6 @@ STATICFILES_DIRS = [
 ]
 
 NODE_MODULES_URL = STATIC_URL + 'node_modules/'
-
 ```
 
 With the SASS function ``get-setting``, you now can override any SASS variable with a configurable
@@ -283,6 +305,8 @@ from you HTML templates.
 * 0.5.0
 - SASS/SCSS files can also be referenced in pure Python files, for instance in ``Media`` class or
   ``media`` property definitions.
+- The SASS processor will look for potential include directories, so that the ``@import "..."``
+  statement also works for SASS files located in other Django apps.
 
 * 0.4.0 - 0.4.4
 - Refactored the sass processor into a self-contained class ``SassProcessor``, which can be accessed

--- a/sass_processor/__init__.py
+++ b/sass_processor/__init__.py
@@ -22,3 +22,5 @@ Release logic:
 """
 
 __version__ = '0.4.6'
+
+default_app_config = 'sass_processor.apps.SassProcessorConfig'

--- a/sass_processor/apps.py
+++ b/sass_processor/apps.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 import os
 from django.apps import apps, AppConfig
+from django.conf import settings
+from django.core.files.storage import get_storage_class
 
 
 APPS_INCLUDE_DIRS = []
@@ -10,17 +12,15 @@ APPS_INCLUDE_DIRS = []
 class SassProcessorConfig(AppConfig):
     name = 'sass_processor'
     verbose_name = "Sass Processor"
-    _static_dir = 'static'
     _sass_exts = ('.scss', '.sass')
+    _storage = get_storage_class(import_path=settings.STATICFILES_STORAGE)()
 
     def ready(self):
         app_configs = apps.get_app_configs()
         for app_config in app_configs:
-            static_dir = os.path.join(app_config.path, self._static_dir)
+            static_dir = os.path.join(app_config.path, self._storage.base_url.strip(os.path.sep))
             if os.path.isdir(static_dir):
                 self.traverse_tree(static_dir)
-
-        print(APPS_INCLUDE_DIRS)
 
     @classmethod
     def traverse_tree(cls, static_dir):

--- a/sass_processor/apps.py
+++ b/sass_processor/apps.py
@@ -16,11 +16,12 @@ class SassProcessorConfig(AppConfig):
     _storage = get_storage_class(import_path=settings.STATICFILES_STORAGE)()
 
     def ready(self):
-        app_configs = apps.get_app_configs()
-        for app_config in app_configs:
-            static_dir = os.path.join(app_config.path, self._storage.base_url.strip(os.path.sep))
-            if os.path.isdir(static_dir):
-                self.traverse_tree(static_dir)
+        if getattr(settings, 'SASS_PROCESSOR_AUTO_INCLUDE', True):
+            app_configs = apps.get_app_configs()
+            for app_config in app_configs:
+                static_dir = os.path.join(app_config.path, self._storage.base_url.strip(os.path.sep))
+                if os.path.isdir(static_dir):
+                    self.traverse_tree(static_dir)
 
     @classmethod
     def traverse_tree(cls, static_dir):

--- a/sass_processor/apps.py
+++ b/sass_processor/apps.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import os
+from django.apps import apps, AppConfig
+
+
+APPS_INCLUDE_DIRS = []
+
+class SassProcessorConfig(AppConfig):
+    name = 'sass_processor'
+    verbose_name = "Sass Processor"
+    _static_dir = 'static'
+    _sass_exts = ('.scss', '.sass')
+
+    def ready(self):
+        app_configs = apps.get_app_configs()
+        for app_config in app_configs:
+            static_dir = os.path.join(app_config.path, self._static_dir)
+            if os.path.isdir(static_dir):
+                self.traverse_tree(static_dir)
+
+        print(APPS_INCLUDE_DIRS)
+
+    @classmethod
+    def traverse_tree(cls, static_dir):
+        """traverse the static folders an look for at least one file ending in .scss/.sass"""
+        for root, dirs, files in os.walk(static_dir):
+            for filename in files:
+                basename, ext = os.path.splitext(filename)
+                if basename.startswith('_') and ext in cls._sass_exts:
+                    APPS_INCLUDE_DIRS.append(static_dir)
+                    return

--- a/sass_processor/management/commands/compilescss.py
+++ b/sass_processor/management/commands/compilescss.py
@@ -64,9 +64,11 @@ class Command(BaseCommand):
             self.parse_template(template_name)
         if self.verbosity > 0:
             if self.delete_files:
-                self.stdout.write('Successfully deleted {0} previously generated `*.css` files.'.format(len(self.compiled_files)))
+                msg = "Successfully deleted {0} previously generated `*.css` files."
+                self.stdout.write(msg.format(len(self.compiled_files)))
             else:
-                self.stdout.write('Successfully compiled {0} referred SASS/SCSS files.'.format(len(self.compiled_files)))
+                msg = "Successfully compiled {0} referred SASS/SCSS files."
+                self.stdout.write(msg.format(len(self.compiled_files)))
 
     def get_parser(self, engine):
         if engine == "jinja2":

--- a/sass_processor/management/commands/compilescss.py
+++ b/sass_processor/management/commands/compilescss.py
@@ -154,7 +154,11 @@ class Command(BaseCommand):
         callvisitor.visit(tree)
         for sass_file in callvisitor.sass_files:
             sass_filename = find_file(sass_file)
-            if sass_filename:
+            if not sass_filename or sass_filename in self.processed_files:
+                continue
+            if self.delete_files:
+                self.delete_file(sass_filename)
+            else:
                 self.compile_sass(sass_filename)
 
     def find_templates(self):

--- a/sass_processor/management/commands/compilescss.py
+++ b/sass_processor/management/commands/compilescss.py
@@ -2,8 +2,10 @@
 from __future__ import unicode_literals
 
 import os
+import ast
 import django
 import sass
+from django.apps import apps
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.template.loader import get_template  # noqa Leave this in to preload template locations
@@ -13,8 +15,23 @@ from django.utils.encoding import force_bytes
 from django.utils.translation import gettext_lazy as _
 from compressor.exceptions import TemplateDoesNotExist, TemplateSyntaxError
 from sass_processor.templatetags.sass_tags import SassSrcNode
+from sass_processor.processor import SassProcessor
 from sass_processor.storage import find_file
 from sass_processor.utils import get_setting
+
+
+class FuncCallVisitor(ast.NodeVisitor):
+    def __init__(self, func_name):
+        self.func_name = func_name
+        self.sass_files = []
+
+    def visit_Call(self, node):
+        try:
+            if node.func.id == self.func_name:
+                arg0 = dict((a, b) for a, b in ast.iter_fields(node))['args'][0]
+                self.sass_files.append(getattr(arg0, arg0._fields[0]))
+        except AttributeError:
+            pass
 
 
 class Command(BaseCommand):
@@ -25,30 +42,37 @@ class Command(BaseCommand):
         self.template_exts = getattr(settings, 'SASS_TEMPLATE_EXTS', ['.html'])
         self.sass_output_style = getattr(settings, 'SASS_OUTPUT_STYLE',
             'nested' if settings.DEBUG else 'compressed')
-        precision = getattr(settings, 'SASS_PRECISION', None)
-        self.sass_precision = int(precision) if precision else None
         self.use_static_root = False
         self.static_root = ''
         super(Command, self).__init__()
 
     def add_arguments(self, parser):
-        parser.add_argument('--delete-files',
+        parser.add_argument(
+            '--delete-files',
             action='store_true',
             dest='delete_files',
             default=False,
             help=_("Delete generated `*.css` files instead of creating them.")
         )
-        parser.add_argument('--use-processor-root',
+        parser.add_argument(
+            '--use-processor-root',
             action='store_true',
             dest='use_processor_root',
             default=False,
             help=_("Store resulting .css in settings.SASS_PROCESSOR_ROOT folder. "
                    "Default: store each css side-by-side with .scss.")
         )
-        parser.add_argument('--engine',
+        parser.add_argument(
+            '--engine',
             dest='engine',
             default='django',
             help=_("Set templating engine used (django, jinja2). Default: django.")
+        )
+        parser.add_argument(
+            '--sass-precision',
+            dest='sass_precision',
+            type=int,
+            help=_("Set the precision for numeric computations in the SASS processor. Default: settings.SASS_PRECISION.")
         )
 
     def handle(self, *args, **options):
@@ -58,11 +82,29 @@ class Command(BaseCommand):
         if self.use_static_root:
             self.static_root = getattr(settings, 'SASS_PROCESSOR_ROOT', settings.STATIC_ROOT)
         self.parser = self.get_parser(options['engine'])
+        try:
+            self.sass_precision = int(options['sass_precision'] or settings.SASS_PRECISION)
+        except (AttributeError, TypeError, ValueError):
+            self.sass_precision = None
+
         self.compiled_files = []
+
+        # find all Python files making up this project; They might invoke `sass_processor`
+        for py_source in self.find_sources():
+            self.parse_source(py_source)
+            if self.verbosity > 0:
+                self.stdout.write(".", ending="")
+
+        # find all Django/Jinja2 templates making up this project; They might invoke `sass_src`
         templates = self.find_templates()
         for template_name in templates:
             self.parse_template(template_name)
+            if self.verbosity > 0:
+                self.stdout.write(".", ending="")
+
+        # summarize what has been done
         if self.verbosity > 0:
+            self.stdout.write("")
             if self.delete_files:
                 msg = "Successfully deleted {0} previously generated `*.css` files."
                 self.stdout.write(msg.format(len(self.compiled_files)))
@@ -83,7 +125,42 @@ class Command(BaseCommand):
 
         return parser
 
+    def find_sources(self):
+        """
+        Look for Python sources available for the current configuration.
+        """
+        app_configs = apps.get_app_configs()
+        for app_config in app_configs:
+            ignore_dirs = []
+            for root, dirs, files in os.walk(app_config.path):
+                if [True for idir in ignore_dirs if root.startswith(idir)]:
+                    continue
+                if '__init__.py' not in files:
+                    ignore_dirs.append(root)
+                    continue
+                for filename in files:
+                    basename, ext = os.path.splitext(filename)
+                    if ext != '.py':
+                        continue
+                    yield os.path.abspath(os.path.join(root, filename))
+
+    def parse_source(self, filename):
+        """
+        Extract the statements from the given file, look for function calls
+        `sass_processor(scss_file)` and compile the filename into CSS.
+        """
+        callvisitor = FuncCallVisitor('sass_processor')
+        tree = ast.parse(open(filename).read())
+        callvisitor.visit(tree)
+        for sass_file in callvisitor.sass_files:
+            sass_filename = find_file(sass_file)
+            if sass_filename:
+                self.compile_sass(sass_filename)
+
     def find_templates(self):
+        """
+        Look for templates and extract the nodes containing the SASS file.
+        """
         paths = set()
         for loader in self.get_loaders():
             try:
@@ -156,43 +233,45 @@ class Command(BaseCommand):
             template = self.parser.parse(template_name)
         except IOError:  # unreadable file -> ignore
             if self.verbosity > 0:
-                self.stdout.write("Unreadable template at: %s\n" % template_name)
+                self.stderr.write("\nUnreadable template at: {}".format(template_name))
             return
         except TemplateSyntaxError as e:  # broken template -> ignore
             if self.verbosity > 0:
-                self.stdout.write("Invalid template %s: %s\n" % (template_name, e))
+                self.stderr.write("\nInvalid template {}: {}".format(template_name, e))
             return
         except TemplateDoesNotExist:  # non existent template -> ignore
             if self.verbosity > 0:
-                self.stdout.write("Non-existent template at: %s\n" % template_name)
+                self.stderr.write("\nNon-existent template at: {}".format(template_name))
             return
         except UnicodeDecodeError:
             if self.verbosity > 0:
-                self.stdout.write("UnicodeDecodeError while trying to read template %s\n" % template_name)
+                self.stderr.write("\nUnicodeDecodeError while trying to read template {}".format(template_name))
         try:
             nodes = list(self.walk_nodes(template, original=template))
         except Exception as e:
             # Could be an error in some base template
             if self.verbosity > 0:
-                self.stdout.write("Error parsing template %s: %s\n" % (template_name, e))
+                self.stderr.write("\nError parsing template {}: {}".format(template_name, e))
         else:
             for node in nodes:
+                sass_filename = find_file(node.path)
+                if not sass_filename:
+                    continue
                 if self.delete_files:
-                    self.delete_file(node)
-                else:
-                    self.compile(node)
+                    self.delete_file(sass_filename)
+                elif sass_filename not in self.compiled_files:
+                    self.compile_sass(sass_filename)
 
-    def compile(self, node):
-        sass_filename = find_file(node.path)
-        if not sass_filename or sass_filename in self.compiled_files:
-            return
-
+    def compile_sass(self, sass_filename):
+        """
+        Compile the given SASS file into CSS
+        """
         # add a functions to be used from inside SASS
         custom_functions = {'get-setting': get_setting}
 
         compile_kwargs = {
             'filename': sass_filename,
-            'include_paths': node.sass_processor.include_paths,
+            'include_paths': SassProcessor.include_paths,
             'custom_functions': custom_functions,
         }
         if self.sass_precision:
@@ -205,15 +284,12 @@ class Command(BaseCommand):
             fh.write(force_bytes(content))
         self.compiled_files.append(sass_filename)
         if self.verbosity > 1:
-            self.stdout.write("Compiled SASS/SCSS file: '{0}'\n".format(node.path))
+            self.stdout.write("Compiled SASS/SCSS file: '{0}'\n".format(sass_filename))
 
-    def delete_file(self, node):
+    def delete_file(self, sass_filename):
         """
         Delete a *.css file, but only if it has been generated through a SASS/SCSS file.
         """
-        sass_filename = find_file(node.path)
-        if not sass_filename:
-            return
         destpath = self.get_destination(sass_filename)
         if os.path.isfile(destpath):
             os.remove(destpath)

--- a/sass_processor/management/commands/compilescss.py
+++ b/sass_processor/management/commands/compilescss.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
         except (AttributeError, TypeError, ValueError):
             self.sass_precision = None
 
-        self.compiled_files = []
+        self.processed_files = []
 
         # find all Python files making up this project; They might invoke `sass_processor`
         for py_source in self.find_sources():
@@ -107,10 +107,10 @@ class Command(BaseCommand):
             self.stdout.write("")
             if self.delete_files:
                 msg = "Successfully deleted {0} previously generated `*.css` files."
-                self.stdout.write(msg.format(len(self.compiled_files)))
+                self.stdout.write(msg.format(len(self.processed_files)))
             else:
                 msg = "Successfully compiled {0} referred SASS/SCSS files."
-                self.stdout.write(msg.format(len(self.compiled_files)))
+                self.stdout.write(msg.format(len(self.processed_files)))
 
     def get_parser(self, engine):
         if engine == "jinja2":
@@ -255,11 +255,11 @@ class Command(BaseCommand):
         else:
             for node in nodes:
                 sass_filename = find_file(node.path)
-                if not sass_filename:
+                if not sass_filename or sass_filename in self.processed_files:
                     continue
                 if self.delete_files:
                     self.delete_file(sass_filename)
-                elif sass_filename not in self.compiled_files:
+                else:
                     self.compile_sass(sass_filename)
 
     def compile_sass(self, sass_filename):
@@ -282,7 +282,7 @@ class Command(BaseCommand):
         destpath = self.get_destination(sass_filename)
         with open(destpath, 'wb') as fh:
             fh.write(force_bytes(content))
-        self.compiled_files.append(sass_filename)
+        self.processed_files.append(sass_filename)
         if self.verbosity > 1:
             self.stdout.write("Compiled SASS/SCSS file: '{0}'\n".format(sass_filename))
 
@@ -293,7 +293,7 @@ class Command(BaseCommand):
         destpath = self.get_destination(sass_filename)
         if os.path.isfile(destpath):
             os.remove(destpath)
-            self.compiled_files.append(sass_filename)
+            self.processed_files.append(sass_filename)
             if self.verbosity > 1:
                 self.stdout.write("Deleted '{0}'\n".format(destpath))
 

--- a/sass_processor/processor.py
+++ b/sass_processor/processor.py
@@ -28,7 +28,6 @@ except NameError:
 class SassProcessor(object):
     storage = SassFileStorage()
     include_paths = list(getattr(settings, 'SASS_PROCESSOR_INCLUDE_DIRS', []))
-    include_paths.extend(APPS_INCLUDE_DIRS)
     prefix = iri_to_uri(getattr(settings, 'STATIC_URL', ''))
     try:
         sass_precision = int(settings.SASS_PRECISION)
@@ -76,7 +75,7 @@ class SassProcessor(object):
         compile_kwargs = {
             'filename': filename,
             'source_map_filename': sourcemap_url,
-            'include_paths': self.include_paths,
+            'include_paths': self.include_paths + APPS_INCLUDE_DIRS,
             'custom_functions': custom_functions,
         }
         if self.sass_precision:

--- a/sass_processor/processor.py
+++ b/sass_processor/processor.py
@@ -12,6 +12,7 @@ from django.utils.six.moves.urllib.parse import urljoin
 from sass_processor.utils import get_setting
 
 from .storage import SassFileStorage, find_file
+from .apps import APPS_INCLUDE_DIRS
 
 try:
     import sass
@@ -28,6 +29,7 @@ class SassProcessor(object):
     def __init__(self, path=None):
         self.storage = SassFileStorage()
         self.include_paths = list(getattr(settings, 'SASS_PROCESSOR_INCLUDE_DIRS', []))
+        self.include_paths.extend(APPS_INCLUDE_DIRS)
         self.prefix = iri_to_uri(getattr(settings, 'STATIC_URL', ''))
         precision = getattr(settings, 'SASS_PRECISION', None)
         self.sass_precision = int(precision) if precision else None

--- a/sass_processor/processor.py
+++ b/sass_processor/processor.py
@@ -26,19 +26,22 @@ except NameError:
 
 
 class SassProcessor(object):
+    storage = SassFileStorage()
+    include_paths = list(getattr(settings, 'SASS_PROCESSOR_INCLUDE_DIRS', []))
+    include_paths.extend(APPS_INCLUDE_DIRS)
+    prefix = iri_to_uri(getattr(settings, 'STATIC_URL', ''))
+    try:
+        sass_precision = int(settings.SASS_PRECISION)
+    except (AttributeError, TypeError, ValueError):
+        sass_precision = None
+    sass_output_style = getattr(
+        settings,
+        'SASS_OUTPUT_STYLE',
+        'nested' if settings.DEBUG else 'compressed')
+    processor_enabled = getattr(settings, 'SASS_PROCESSOR_ENABLED', settings.DEBUG)
+    sass_extensions = ('.scss', '.sass')
+
     def __init__(self, path=None):
-        self.storage = SassFileStorage()
-        self.include_paths = list(getattr(settings, 'SASS_PROCESSOR_INCLUDE_DIRS', []))
-        self.include_paths.extend(APPS_INCLUDE_DIRS)
-        self.prefix = iri_to_uri(getattr(settings, 'STATIC_URL', ''))
-        precision = getattr(settings, 'SASS_PRECISION', None)
-        self.sass_precision = int(precision) if precision else None
-        self.sass_output_style = getattr(
-            settings,
-            'SASS_OUTPUT_STYLE',
-            'nested' if settings.DEBUG else 'compressed')
-        self.processor_enabled = getattr(settings, 'SASS_PROCESSOR_ENABLED', settings.DEBUG)
-        self._sass_exts = ('.scss', '.sass')
         self._path = path
 
     def __call__(self, path):
@@ -47,7 +50,7 @@ class SassProcessor(object):
         if filename is None:
             raise FileNotFoundError("Unable to locate file {path}".format(path=path))
 
-        if ext not in self._sass_exts:
+        if ext not in self.sass_extensions:
             # return the given path, since it ends neither in `.scss` nor in `.sass`
             return urljoin(self.prefix, path)
 
@@ -98,7 +101,7 @@ class SassProcessor(object):
 
     def is_sass(self):
         _, ext = os.path.splitext(self.resolve_path())
-        return ext in self._sass_exts
+        return ext in self.sass_extensions
 
     def is_latest(self, sourcemap_filename):
         sourcemap_file = find_file(sourcemap_filename)
@@ -114,3 +117,8 @@ class SassProcessor(object):
                 # at least one of the source is younger that the sourcemap referring it
                 return False
         return True
+
+
+_sass_processor = SassProcessor()
+def sass_processor(filename):
+    return _sass_processor(filename)

--- a/sass_processor/templatetags/sass_tags.py
+++ b/sass_processor/templatetags/sass_tags.py
@@ -39,10 +39,10 @@ class SassSrcNode(Node):
             url = self.sass_processor(path)
         except AttributeError:
             msg = "No sass/scss file specified while rendering tag 'sass_src' in template {}"
-            raise TemplateSyntaxError(msg.format(self.source[0].name))
+            raise TemplateSyntaxError(msg.format(context.template_name))
         except FileNotFoundError as e:
             msg = str(e) + " while rendering tag 'sass_src' in template {}"
-            raise TemplateSyntaxError(msg.format(self.source[0].name))
+            raise TemplateSyntaxError(msg.format(context.template_name))
         return url
 
 @register.tag(name='sass_src')


### PR DESCRIPTION
In version 0.4.6 I introduced the possibility to also refer to SASS/SCSS files in pure Python. This is specially handy in ``Media`` classes and ``media`` properties, often used in Django Forms and the Admin.

However, offline compilation was not supported then, because it requires to parse Python files, which is much harder than parsing Django templates. Fortunately, Python can parse itself and generate an [Abstract Syntax Tree](https://docs.python.org/3/library/ast.html) out of it's sources. This now is used to extract invocations to ``sass_processor(...)``.

This new feature had however some impact on the code which had to be refactored.

@Arany @AndreasBackx : Please review this pull request, so that I can release version 0.5. Thanks.
