### PR TITLE
Jinja2 extension now accepts both strings and variables.

### DIFF
--- a/sass_processor/jinja2/ext.py
+++ b/sass_processor/jinja2/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from jinja2 import lexer, nodes
+from jinja2 import nodes
 from jinja2.ext import Extension
 from sass_processor.processor import SassProcessor
 
@@ -11,11 +11,7 @@ class SassSrc(Extension):
 
     def parse(self, parser):
         lineno = next(parser.stream).lineno
-
-        token = parser.stream.expect(
-            lexer.TOKEN_STRING
-        )
-        path = nodes.Const(token.value)
+        path = parser.parse_expression()
 
         call = self.call_method(
             '_sass_src_support', [


### PR DESCRIPTION
This fixes #54.

It allows for the following construct:
```jinja
{% set SASS_FILE = 'main.scss' %}
<link type="text/css" rel="stylesheet" href="{% sass_src SASS_FILE %}">
```

When in the past, it only allowed this:
```jinja
<link type="text/css" rel="stylesheet" href="{% sass_src 'main.scss' %}">
```