### PR TITLE
Correctly lookup app's 'static' folders to include

### DIFF
--- a/sass_processor/apps.py
+++ b/sass_processor/apps.py
@@ -5,6 +5,7 @@ import re
 import os
 from django.apps import apps, AppConfig
 from django.conf import settings
+from django.contrib.staticfiles.finders import AppDirectoriesFinder
 from django.core.files.storage import get_storage_class
 
 
@@ -21,7 +22,7 @@ class SassProcessorConfig(AppConfig):
         if self._auto_include:
             app_configs = apps.get_app_configs()
             for app_config in app_configs:
-                static_dir = os.path.join(app_config.path, self._storage.base_url.strip(os.path.sep))
+                static_dir = os.path.join(app_config.path, AppDirectoriesFinder.source_dir)
                 if os.path.isdir(static_dir):
                     self.traverse_tree(static_dir)
 


### PR DESCRIPTION
As explained in #73, currently when `STATIC_URL = '/static/'` in settings, django-sass-processor fails to add apps static directories to include paths on Windows.

In addition, from the documentation :

> django-sass-processor will traverse all installed Django apps (INSTALLED_APPS) and look into their static folders. If any of them contain a file matching the regular expression [...], then that app specific static folder is added to the libsass include dirs.

Currently, the value used to compute the path to app's `static` directory is the storage's `base_url` attribute corresponding to value of `settings.STATIC_URL`.

If `STATIC_URL = '/anything/'`, the files will be searched into `/path/to/project/app/anything` instead of `/path/to/project/app/static` on any platform.

This PR is an attempt to fix these issues, by using `AppDirectoriesFinder.source_dir` as directory name to search into for sass files at startup.

Note that currently, Django does not allow to customize the name of the static directory for all applications.
