### PR TITLE
remove libsass from dependencies, add Django 2.0 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,15 @@ python:
   - 3.6
 
 env:
+  - DJANGOVER=django20
   - DJANGOVER=django19
   - DJANGOVER=django110
   - DJANGOVER=django111
+
+matrix:
+  exclude:
+    - python: 2.7
+      env: DJANGOVER=django20
 
 install:
   - pip install tox

--- a/README.md
+++ b/README.md
@@ -11,31 +11,29 @@ third party services nor special IDE plugins.
 [![PyPI](https://img.shields.io/pypi/l/django-sass-processor.svg)]()
 [![Twitter Follow](https://img.shields.io/twitter/follow/shields_io.svg?style=social&label=Follow&maxAge=2592000)](https://twitter.com/jacobrief)
 
-**django-sass-processor** converts ``*.scss`` or ``*.sass`` files into ``*.css`` while rendering
+**django-sass-processor** converts `*.scss` or `*.sass` files into `*.css` while rendering
 templates. For performance reasons this is done only once, since the preprocessor keeps track on
 the timestamps and only recompiles, if any of the imported SASS/SCSS files is younger than the
 corresponding generated CSS file.
 
-
 ## Introduction
 
-This Django app provides a templatetag ``{% sass_src 'path/to/file.scss' %}``, which can be used
-instead of the built-in templatetag ``static``. This templatetag also works inside Jinja2 templates.
+This Django app provides a templatetag `{% sass_src 'path/to/file.scss' %}`, which can be used
+instead of the built-in templatetag `static`. This templatetag also works inside Jinja2 templates.
 
-If SASS/SCSS files shall be referenced through the ``Media`` class, or ``media`` property, the SASS
+If SASS/SCSS files shall be referenced through the `Media` class, or `media` property, the SASS
 processor can be used directly.
 
 Additionally, **django-sass-processor** is shipped with a management command, which can convert
-the content of all occurrences inside the templatetag ``sass_src`` as an offline operation. Hence
+the content of all occurrences inside the templatetag `sass_src` as an offline operation. Hence
 the **libsass** compiler is not required in a production environment.
 
 During development, a [sourcemap](https://developer.chrome.com/devtools/docs/css-preprocessors) is
-generated along side with the compiled ``*.css`` file. This allows to debug style sheet errors much
+generated along side with the compiled `*.css` file. This allows to debug style sheet errors much
 easier.
 
 With this tool, you can safely remove your Ruby installations "Compass" and "SASS" from your Django
 projects. You neither need any directory "watching" daemons based on node.js.
-
 
 ## Project's Home
 
@@ -45,23 +43,21 @@ https://github.com/jrief/django-sass-processor
 
 Please use the issue tracker to report bugs or propose new features.
 
-
 ## Installation
 
 ```
 pip install libsass django-compressor django-sass-processor
 ```
 
-``django-compressor`` is required only for offline compilation, when using the command
-``manage.py compilescss``.
+`django-compressor` is required only for offline compilation, when using the command
+`manage.py compilescss`.
 
-``libsass`` is not required on the production environment, if SASS/SCSS files have been precompiled
+`libsass` is not required on the production environment, if SASS/SCSS files have been precompiled
 and deployed using offline compilation.
-
 
 ## Configuration
 
-In ``settings.py`` add to:
+In `settings.py` add to:
 
 ```python
 INSTALLED_APPS = [
@@ -72,7 +68,7 @@ INSTALLED_APPS = [
 ```
 
 Optionally, add a list of additional search paths, the SASS compiler may examine when using the
-``@import "...";`` statement in SASS/SCSS files:
+`@import "...";` statement in SASS/SCSS files:
 
 ```python
 import os
@@ -83,17 +79,17 @@ SASS_PROCESSOR_INCLUDE_DIRS = [
 ]
 ```
 
-Additionally, **django-sass-processor** will traverse all installed Django apps (``INSTALLED_APPS``)
+Additionally, **django-sass-processor** will traverse all installed Django apps (`INSTALLED_APPS`)
 and look into their static folders. If any of them contain a file matching the regular expression
-pattern ``^_.+\.(scss|sass)$`` (read: filename starts with an underscore and is of type ``scss`` or
-``sass``), then that app specific static folder is added to the **libsass** include dirs. This
+pattern `^_.+\.(scss|sass)$` (read: filename starts with an underscore and is of type `scss` or
+`sass`), then that app specific static folder is added to the **libsass** include dirs. This
 feature can be disabled in your settings with:
 
 ```python
 SASS_PROCESSOR_AUTO_INCLUDE = False
 ```
 
-If inside of your SASS/SCSS files, you also want to import (using ``@import "path/to/scssfile";``)
+If inside of your SASS/SCSS files, you also want to import (using `@import "path/to/scssfile";`)
 files which do not start with an underscore, then you can configure another Regex pattern in your
 settings, for instance:
 
@@ -101,26 +97,26 @@ settings, for instance:
 SASS_PROCESSOR_INCLUDE_FILE_PATTERN = r'^.+\.scss$'
 ```
 
-will look for all files of type ``scss``. Remember that SASS/SCSS files which start with an
+will look for all files of type `scss`. Remember that SASS/SCSS files which start with an
 underscore, are intended to be imported by other SASS/SCSS files, while files starting with a
 letter or number are intended to be included by the HTML tag
-``<link href="{% sass_src 'path/to/file.scss' %}" ...>``.
+`<link href="{% sass_src 'path/to/file.scss' %}" ...>`.
 
-During development, or when ``SASS_PROCESSOR_ENABLED = True``, the compiled file is placed into the
-folder referenced by ``SASS_PROCESSOR_ROOT`` (if unset, this setting defaults to ``STATIC_ROOT``).
-Having a location outside of the working directory prevents to pollute your local ``static/css/...``
+During development, or when `SASS_PROCESSOR_ENABLED = True`, the compiled file is placed into the
+folder referenced by `SASS_PROCESSOR_ROOT` (if unset, this setting defaults to `STATIC_ROOT`).
+Having a location outside of the working directory prevents to pollute your local `static/css/...`
 directories with auto-generated files. Therefore assure, that this directory is writable by the
 Django runserver.
 
-**django-sass-processor** is shipped with a special finder, to locate the generated ``*.css`` files
-in the directory referred by ``SASS_PROCESSOR_ROOT`` (or, if unset ``STATIC_ROOT``). Just add it to
-your ``settings.py``. If there is no ``STATICFILES_FINDERS`` in your ``settings.py`` don't forget
+**django-sass-processor** is shipped with a special finder, to locate the generated `*.css` files
+in the directory referred by `SASS_PROCESSOR_ROOT` (or, if unset `STATIC_ROOT`). Just add it to
+your `settings.py`. If there is no `STATICFILES_FINDERS` in your `settings.py` don't forget
 to include the **Django** [default finders](https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-STATICFILES_FINDERS).
 
-If the directory referred by ``SASS_PROCESSOR_ROOT`` does not exist, then **django-sass-processor**
-creates it. This does does not apply, if ``SASS_PROCESSOR_ROOT`` is unset and hence defaults to
-``STATIC_ROOT``. Therefore it is a good idea to otherwise use ``SASS_PROCESSOR_ROOT = STATIC_ROOT``
-in your ``settings.py``.
+If the directory referred by `SASS_PROCESSOR_ROOT` does not exist, then **django-sass-processor**
+creates it. This does does not apply, if `SASS_PROCESSOR_ROOT` is unset and hence defaults to
+`STATIC_ROOT`. Therefore it is a good idea to otherwise use `SASS_PROCESSOR_ROOT = STATIC_ROOT`
+in your `settings.py`.
 
 ```python
 STATICFILES_FINDERS = [
@@ -131,23 +127,25 @@ STATICFILES_FINDERS = [
 ]
 ```
 
-#### Fine tune SASS compiler parameters in ``settings.py``.
+#### Fine tune SASS compiler parameters in `settings.py`.
 
 Integer `SASS_PRECISION` sets floating point precision for output css. libsass'
-default is ``5``. Note: **bootstrap-sass** requires ``8``, otherwise various
+default is `5`. Note: **bootstrap-sass** requires `8`, otherwise various
 layout problems _will_ occur.
+
 ```python
 SASS_PRECISION = 8
 ```
 
-`SASS_OUTPUT_STYLE` sets coding style of the compiled result, one of ``compact``,
-``compressed``, ``expanded``, or ``nested``. Default is ``nested`` for ``DEBUG``
-and ``compressed`` in production.
+`SASS_OUTPUT_STYLE` sets coding style of the compiled result, one of `compact`,
+`compressed`, `expanded`, or `nested`. Default is `nested` for `DEBUG`
+and `compressed` in production.
 
 Note: **libsass-python** 0.8.3 has [problem encoding result while saving on
 Windows](https://github.com/dahlia/libsass-python/pull/82), the issue is already
 fixed and will be included in future `pip` package release, in the meanwhile
-avoid ``compressed`` output style.
+avoid `compressed` output style.
+
 ```python
 SASS_OUTPUT_STYLE = 'compact'
 ```
@@ -157,6 +155,7 @@ SASS_OUTPUT_STYLE = 'compact'
 `sass_processor.jinja2.ext.SassSrc` is a Jinja2 extension. Add it to your Jinja2 environment to enable the tag `sass_src`, there is no need for a `load` tag. Example of how to add your Jinja2 environment to Django:
 
 In `settings.py`:
+
 ```python
 TEMPLATES = [{
     'BACKEND': 'django.template.backends.jinja2.Jinja2',
@@ -173,6 +172,7 @@ Make sure to add the default template backend, if you're still using Django temp
 This is covered in the [Upgrading templates documentation](https://docs.djangoproject.com/en/stable/ref/templates/upgrading/).
 
 In `yourapp/jinja2.py`:
+
 ```python
 # Include this for Python 2.
 from __future__ import absolute_import
@@ -189,6 +189,7 @@ def environment(**kwargs):
 ```
 
 If you want to make use of the `compilescss` command, then you will also have to add the following to your settings:
+
 ```python
 from yourapp.jinja2 import environment
 
@@ -211,8 +212,7 @@ The above template code will be rendered as HTML
 <link href="/static/myapp/css/mystyle.css" rel="stylesheet" type="text/css" />
 ```
 
-You can safely use this templatetag inside a Sekizai's ``{% addtoblock "css" %}`` statement.
-
+You can safely use this templatetag inside a Sekizai's `{% addtoblock "css" %}` statement.
 
 ### In Media classes or properties
 
@@ -230,11 +230,11 @@ class SomeAdminOrFormClass(...):
         }
 ```
 
-
 ## Offline compilation
 
 If you want to precompile all occurrences of your SASS/SCSS files for the whole project, on the
 command line invoke:
+
 ```shell
 ./manage.py compilescss
 ```
@@ -242,47 +242,54 @@ command line invoke:
 This is useful for preparing production environments, where SASS/SCSS files can't be compiled on
 the fly.
 
-To simplify the deployment, the compiled ``*.css`` files are stored side-by-side with their
+To simplify the deployment, the compiled `*.css` files are stored side-by-side with their
 corresponding SASS/SCSS files. After compiling the files run
+
 ```shell
 ./manage.py collectstatic
 ```
+
 as you would in a normal deployment.
 
 In case you don't want to expose the SASS/SCSS files in a production environment,
 deploy with:
+
 ```shell
 ./manage.py collectstatic --ignore=*.scss
 ```
 
-To get rid of the compiled ``*.css`` files in your local static directories, simply reverse the
+To get rid of the compiled `*.css` files in your local static directories, simply reverse the
 above command:
+
 ```shell
 ./manage.py compilescss --delete-files
 ```
-This will remove all occurrences of previously generated ``*.css`` files.
 
-Or you may compile results to the ``SASS_PROCESSOR_ROOT`` directory directy (if not specified - to
-``STATIC_ROOT``):
+This will remove all occurrences of previously generated `*.css` files.
+
+Or you may compile results to the `SASS_PROCESSOR_ROOT` directory directy (if not specified - to
+`STATIC_ROOT`):
+
 ```shell
 ./manage.py compilescss --use-processor-root
 ```
-Combine with ``--delete-files`` switch to purge results from there.
 
-If you use an alternative templating engine set its name in ``--engine`` argument. Currently
-``django`` and ``jinja2`` are supported, see
+Combine with `--delete-files` switch to purge results from there.
+
+If you use an alternative templating engine set its name in `--engine` argument. Currently
+`django` and `jinja2` are supported, see
 [django-compressor documentation](http://django-compressor.readthedocs.org/en/latest/) on how to
-set up ``COMPRESS_JINJA2_GET_ENVIRONMENT`` to configure jinja2 engine support.
+set up `COMPRESS_JINJA2_GET_ENVIRONMENT` to configure jinja2 engine support.
 
 During offline compilation **django-sass-processor** parses all Python files and looks for
-invocations of ``sass_processor('path/to/sassfile.scss')``. Therefore the string specifying
+invocations of `sass_processor('path/to/sassfile.scss')`. Therefore the string specifying
 the filename must be hard coded and shall not be concatenated or being somehow generated.
-
 
 ### Alternative templates
 
 By default, **django-sass-processor** will locate SASS/SCSS files from .html templates,
 but you can extend or override this behavior in your settings with:
+
 ```python
 SASS_TEMPLATE_EXTS = ['.html','.jade']
 ```
@@ -290,19 +297,20 @@ SASS_TEMPLATE_EXTS = ['.html','.jade']
 ## Configure SASS variables through settings.py
 
 In SASS, a nasty problem is to set the correct include paths for icons and fonts. Normally this is
-done through a ``_variables.scss`` file, but this inhibits a configuration through your projects
-``settings.py``.
+done through a `_variables.scss` file, but this inhibits a configuration through your projects
+`settings.py`.
 
 To avoid the need for duplicate configuration settings, **django-sass-processor** offers a SASS
-function to fetch any arbitrary configuration directive from the project's ``settings.py``. This
+function to fetch any arbitrary configuration directive from the project's `settings.py`. This
 is specially handy to set the include path of your Glyphicons font directory. Assume, Bootstrap-SASS
 has been installed using:
+
 ```shell
 npm install bootstrap-sass
 ```
 
-then locate the directory named ``node_modules`` and add it to your settings, so that your fonts are
-accessible through the Django's ``django.contrib.staticfiles.finders.FileSystemFinder``:
+then locate the directory named `node_modules` and add it to your settings, so that your fonts are
+accessible through the Django's `django.contrib.staticfiles.finders.FileSystemFinder`:
 
 ```python
 STATICFILES_DIRS = [
@@ -314,18 +322,17 @@ STATICFILES_DIRS = [
 NODE_MODULES_URL = STATIC_URL + 'node_modules/'
 ```
 
-With the SASS function ``get-setting``, it now is possible to override any SASS variable with a
-value configured in the project's ``settings.py``. For the Glyphicons font search path, add this
-to your ``_variables.scss``:
+With the SASS function `get-setting`, it now is possible to override any SASS variable with a
+value configured in the project's `settings.py`. For the Glyphicons font search path, add this
+to your `_variables.scss`:
 
 ```
 $icon-font-path: unquote(get-setting(NODE_MODULES_URL) + "bootstrap-sass/assets/fonts/bootstrap/");
 ```
 
-and ``@import "variables";`` whenever you need Glyphicons. You then can safely remove any font
-references, such as ``<link href="/path/to/your/fonts/bootstrap/glyphicons-whatever.ttf" ...>``
+and `@import "variables";` whenever you need Glyphicons. You then can safely remove any font
+references, such as `<link href="/path/to/your/fonts/bootstrap/glyphicons-whatever.ttf" ...>`
 from you HTML templates.
-
 
 ## Development
 
@@ -340,73 +347,94 @@ tox
 
 ## Changelog
 
-* 0.5.7
-- Fixed: Catch exception if s3boto is not installed.
+* _Potentially Breaking_: `libsass` is not autoinstalled as the dependency anymore.
 
-* 0.5.6
-- Added compatibility layer to work with AWS S3 Storage.
+- 0.5.7
 
-* 0.5.5
-- Create directory ``SASS_PROCESSOR_ROOT`` if it does not exist.
+* Fixed: Catch exception if s3boto is not installed.
 
-* 0.5.4
-- Added unit tests and continuous integration to the project.
+- 0.5.6
 
-* 0.5.3
-- Fixed compilescss: Did not find calls of sass_processor within a dict, list or tuple
+* Added compatibility layer to work with AWS S3 Storage.
 
-* 0.5.2
-- Fixed Python 3 incompatibility. Open files as binaries, since they may contain unicode characters.
+- 0.5.5
 
-* 0.5.1
-- Add ``APPS_INCLUDE_DIRS`` to the SASS include path.
+* Create directory `SASS_PROCESSOR_ROOT` if it does not exist.
 
-* 0.5.0
-- SASS/SCSS files can also be referenced in pure Python files, for instance in ``Media`` class or
-  ``media`` property definitions.
-- The SASS processor will look for potential include directories, so that the ``@import "..."``
+- 0.5.4
+
+* Added unit tests and continuous integration to the project.
+
+- 0.5.3
+
+* Fixed compilescss: Did not find calls of sass_processor within a dict, list or tuple
+
+- 0.5.2
+
+* Fixed Python 3 incompatibility. Open files as binaries, since they may contain unicode characters.
+
+- 0.5.1
+
+* Add `APPS_INCLUDE_DIRS` to the SASS include path.
+
+- 0.5.0
+
+* SASS/SCSS files can also be referenced in pure Python files, for instance in `Media` class or
+  `media` property definitions.
+* The SASS processor will look for potential include directories, so that the `@import "..."`
   statement also works for SASS files located in other Django apps.
 
-* 0.4.0 - 0.4.4
-- Refactored the sass processor into a self-contained class ``SassProcessor``, which can be accessed
+- 0.4.0 - 0.4.4
+
+* Refactored the sass processor into a self-contained class `SassProcessor`, which can be accessed
   through an API, the Jinja2 template engine and the existing templatetag.
 
-* 0.3.5
- - Added Jinja2 support, see [Jinja2 support](#jinja2-support).
+- 0.3.5
 
-* 0.3.4
- - Fixed: ``get_template_sources()`` in Django-1.9 returns Objects rather than strings.
- - In command, use ``ArgumentParser`` rather than ``OptionParser``.
+* Added Jinja2 support, see [Jinja2 support](#jinja2-support).
 
-* 0.3.1...0.3.3
- - Changed the build process in ``setup.py``.
+- 0.3.4
 
-* 0.3.0
- - Compatible with Django 1.8+.
- - bootstrap3-sass ready: appropriate floating point precision (8) can be set in ``settings.py``.
- - Offline compilation results may optionally be stored in ``SASS_PROCESSOR_ROOT``.
+* Fixed: `get_template_sources()` in Django-1.9 returns Objects rather than strings.
+* In command, use `ArgumentParser` rather than `OptionParser`.
 
-* 0.2.6
- - Hotfix: added SASS function ``get-setting`` also to offline compiler.
+- 0.3.1...0.3.3
 
-* 0.2.5
- - Compatible with Python3
- - Replaced ``SortedDict`` with ``OrderedDict`` to be prepared for Django-1.9
- - Raise a ``TemplateSyntax`` error, if a SASS ``@include "..."`` fails to find the file.
- - Added SASS function ``get-setting`` to fetch configuration directives from ``settings.py``.
+* Changed the build process in `setup.py`.
 
-* 0.2.4
- - Forcing compiled unicode to bytes, since 'Font Awesome' uses Unicode Private Use Area (PUA)
-   and hence implicit conversion on ``fh.write()`` failed.
+- 0.3.0
 
-* 0.2.3
- - Allow for setting template extensions and output style.
- - Force Django to calculate template_source_loaders from TEMPLATE_LOADERS settings, by asking to find a dummy template.
+* Compatible with Django 1.8+.
+* bootstrap3-sass ready: appropriate floating point precision (8) can be set in `settings.py`.
+* Offline compilation results may optionally be stored in `SASS_PROCESSOR_ROOT`.
 
-* 0.2.0
- - Removed dependency to **django-sekizai** and **django-classy-tags**. It now can operate in
-   stand-alone mode. Therefore the project has been renamed to **django-sass-processor**.
+- 0.2.6
 
-* 0.1.0
- - Initial revision named **django-sekizai-processors**, based on a preprocessor for the Sekizai
-   template tags ``{% addtoblock %}``.
+* Hotfix: added SASS function `get-setting` also to offline compiler.
+
+- 0.2.5
+
+* Compatible with Python3
+* Replaced `SortedDict` with `OrderedDict` to be prepared for Django-1.9
+* Raise a `TemplateSyntax` error, if a SASS `@include "..."` fails to find the file.
+* Added SASS function `get-setting` to fetch configuration directives from `settings.py`.
+
+- 0.2.4
+
+* Forcing compiled unicode to bytes, since 'Font Awesome' uses Unicode Private Use Area (PUA)
+  and hence implicit conversion on `fh.write()` failed.
+
+- 0.2.3
+
+* Allow for setting template extensions and output style.
+* Force Django to calculate template_source_loaders from TEMPLATE_LOADERS settings, by asking to find a dummy template.
+
+- 0.2.0
+
+* Removed dependency to **django-sekizai** and **django-classy-tags**. It now can operate in
+  stand-alone mode. Therefore the project has been renamed to **django-sass-processor**.
+
+- 0.1.0
+
+* Initial revision named **django-sekizai-processors**, based on a preprocessor for the Sekizai
+  template tags `{% addtoblock %}`.

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     author_email='jacob.rief@gmail.com',
     url='https://github.com/jrief/django-sass-processor',
     packages=find_packages(),
-    install_requires=['libsass'],
+    install_requires=[],
     license='LICENSE-MIT',
     platforms=['OS Independent'],
     classifiers=CLASSIFIERS,

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py{35}-django{19,110,111}
+envlist = py{35}-django{20,19,110,111}
 
 [testenv]
 deps =
+    django20: Django>=2.0,<3.0
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12


### PR DESCRIPTION
Fixes #77

I've verified it with my project (using as `-e` dependency) and all looks good.
I'm also using Django 2.0 and things work so I think you can test against this version.