### PR TITLE
From SCSS call into Python functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 local_settings.py
 db.sqlite3
 media
+.pytest_cache
 
 ### Linux ###
 *~

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ your source tree.
 Use Django's settings for the configuration of pathes, box sizes etc., instead of having another
 SCSS specific file (typically ``_variables.scss``), to hold these.
 
+Extend your SASS functions by calling Python functions directly out of your Django project.
+
 
 [![Build Status](https://travis-ci.org/jrief/django-sass-processor.svg)](https://travis-ci.org/jrief/django-sass-processor)
 [![PyPI](https://img.shields.io/pypi/pyversions/django-sass-processor.svg)]()

--- a/README.md
+++ b/README.md
@@ -365,17 +365,29 @@ STATICFILES_DIRS = [
 NODE_MODULES_URL = STATIC_URL + 'node_modules/'
 ```
 
-With the SASS function `get-setting`, it now is possible to override any SASS variable with a
-value configured in the project's `settings.py`. For the Glyphicons font search path, add this
-to your `_variables.scss`:
+With the SASS function `get-setting`, it is possible to override any SASS variable with a value
+configured in the project's `settings.py`. For the Glyphicons font search path, add this to your
+`_variables.scss`:
 
-```
+```scss
 $icon-font-path: unquote(get-setting(NODE_MODULES_URL) + "bootstrap-sass/assets/fonts/bootstrap/");
 ```
 
 and `@import "variables";` whenever you need Glyphicons. You then can safely remove any font
 references, such as `<link href="/path/to/your/fonts/bootstrap/glyphicons-whatever.ttf" ...>`
 from you HTML templates.
+
+There is another set of SASS functions, named `python-call0`, `python-call1`, `python-call2` and
+`python-call3`. With these it is possible to call any Python function reachable in your
+project. The postfix digit specifies the number of passed in parameters. Example:
+
+```scss
+$color: python-call1('myproject.utils.get_alarm_color', $severity);
+```
+
+This will pass the content of the variable ``$severity`` into the function
+``def get_alarm_color(severity)`` in Python module ``myproject.utils``.
+
 
 ## Serving static files with S3
 

--- a/README.md
+++ b/README.md
@@ -377,16 +377,32 @@ and `@import "variables";` whenever you need Glyphicons. You then can safely rem
 references, such as `<link href="/path/to/your/fonts/bootstrap/glyphicons-whatever.ttf" ...>`
 from you HTML templates.
 
-There is another set of SASS functions, named `python-call0`, `python-call1`, `python-call2` and
-`python-call3`. With these it is possible to call any Python function reachable in your
-project. The postfix digit specifies the number of passed in parameters. Example:
+It is even possible to call Python functions from inside any module. Do this by adding
+`SASS_PROCESSOR_FUNCTIONS` to the project's `settings.py`. This shall contain a mapping
+of SASS function names pointing to a Python function name.
 
-```scss
-$color: python-call1('myproject.utils.get_alarm_color', $severity);
+Example:
+
+```python
+SASS_PROCESSOR_FUNCTIONS = {
+    'get-color': 'myproject.utils.get_color',
+}
 ```
 
-This will pass the content of the variable ``$severity`` into the function
-``def get_alarm_color(severity)`` in Python module ``myproject.utils``.
+```scss
+$color: get-color(250, 10, 120);
+```
+
+This will pass the parameters '250, 10, 120' into the function `def get_color(red, green, blue)`
+in Python module `myproject.utils`. Note that this function receives the values as `sass.Number`,
+hence extract values using `red.value`, etc.
+
+If one of these customoized functions returns a value, which is not a string, then convert it
+either to a Python string or to a value of type `sass.SassNumber`. For other types, refer to their
+documentation.
+
+Such customized functions must accept parameters explicilty, otherwise `sass_processor` does not
+know how to map them. Variable argument lists therefore can not be used.
 
 
 ## Serving static files with S3

--- a/README.md
+++ b/README.md
@@ -428,6 +428,10 @@ tox
 
 ## Changelog
 
+- 0.7
+
+* Allow to call directly into Python functions.
+
 - 0.6
 
 * Add autoprefixing via external postcss.

--- a/sass_processor/__init__.py
+++ b/sass_processor/__init__.py
@@ -21,6 +21,6 @@ Release logic:
 13. git push
 """
 
-__version__ = '0.6'
+__version__ = '0.7'
 
 default_app_config = 'sass_processor.apps.SassProcessorConfig'

--- a/sass_processor/management/commands/compilescss.py
+++ b/sass_processor/management/commands/compilescss.py
@@ -21,7 +21,7 @@ from sass_processor.apps import APPS_INCLUDE_DIRS
 from sass_processor.processor import SassProcessor
 from sass_processor.storage import SassFileStorage, find_file
 from sass_processor.templatetags.sass_tags import SassSrcNode
-from sass_processor.utils import custom_functions
+from sass_processor.utils import get_custom_functions
 
 __all__ = ['get_template', 'Command']
 
@@ -277,7 +277,7 @@ class Command(BaseCommand):
         compile_kwargs = {
             'filename': sass_filename,
             'include_paths': SassProcessor.include_paths + APPS_INCLUDE_DIRS,
-            'custom_functions': custom_functions,
+            'custom_functions': get_custom_functions(),
         }
         if self.sass_precision:
             compile_kwargs['precision'] = self.sass_precision

--- a/sass_processor/management/commands/compilescss.py
+++ b/sass_processor/management/commands/compilescss.py
@@ -21,7 +21,7 @@ from sass_processor.apps import APPS_INCLUDE_DIRS
 from sass_processor.processor import SassProcessor
 from sass_processor.storage import SassFileStorage, find_file
 from sass_processor.templatetags.sass_tags import SassSrcNode
-from sass_processor.utils import get_setting
+from sass_processor.utils import custom_functions
 
 __all__ = ['get_template', 'Command']
 
@@ -274,9 +274,6 @@ class Command(BaseCommand):
         """
         Compile the given SASS file into CSS
         """
-        # add a functions to be used from inside SASS
-        custom_functions = {'get-setting': get_setting}
-
         compile_kwargs = {
             'filename': sass_filename,
             'include_paths': SassProcessor.include_paths + APPS_INCLUDE_DIRS,

--- a/sass_processor/processor.py
+++ b/sass_processor/processor.py
@@ -13,7 +13,7 @@ from django.templatetags.static import PrefixNode
 from django.utils.encoding import force_bytes
 from django.utils import six
 from django.utils.six.moves.urllib.parse import quote, urljoin
-from sass_processor.utils import get_setting
+from sass_processor.utils import custom_functions
 
 from .storage import SassFileStorage, find_file
 from .apps import APPS_INCLUDE_DIRS
@@ -72,9 +72,6 @@ class SassProcessor(object):
         if sass is None:
             msg = "Offline compiled file `{}` is missing and libsass has not been installed."
             raise ImproperlyConfigured(msg.format(css_filename))
-
-        # add a function to be used from inside SASS
-        custom_functions = {'get-setting': get_setting}
 
         # otherwise compile the SASS/SCSS file into .css and store it
         sourcemap_url = self.storage.url(sourcemap_filename)

--- a/sass_processor/processor.py
+++ b/sass_processor/processor.py
@@ -13,7 +13,7 @@ from django.templatetags.static import PrefixNode
 from django.utils.encoding import force_bytes
 from django.utils import six
 from django.utils.six.moves.urllib.parse import quote, urljoin
-from sass_processor.utils import custom_functions
+from sass_processor.utils import get_custom_functions
 
 from .storage import SassFileStorage, find_file
 from .apps import APPS_INCLUDE_DIRS
@@ -79,7 +79,7 @@ class SassProcessor(object):
             'filename': filename,
             'source_map_filename': sourcemap_url,
             'include_paths': self.include_paths + APPS_INCLUDE_DIRS,
-            'custom_functions': custom_functions,
+            'custom_functions': get_custom_functions(),
         }
         if self.sass_precision:
             compile_kwargs['precision'] = self.sass_precision

--- a/sass_processor/types.py
+++ b/sass_processor/types.py
@@ -1,0 +1,10 @@
+from decimal import Decimal
+from sass import SassNumber as _SassNumber, SassColor, SassList, SassMap
+
+__all__ = ['SassNumber', 'SassColor', 'SassList', 'SassMap']
+
+
+def SassNumber(value):
+    if isinstance(value, (int, float, Decimal)):
+        return str(_SassNumber(value, type(value).__name__.encode()).value)
+    return value

--- a/sass_processor/utils.py
+++ b/sass_processor/utils.py
@@ -14,7 +14,7 @@ def get_setting(*args):
     try:
         return getattr(settings, args[0])
     except AttributeError as e:
-        raise TemplateSyntaxError(e.message)
+        raise TemplateSyntaxError(str(e))
 
 
 def python_call(*args):
@@ -22,7 +22,7 @@ def python_call(*args):
         func = import_string(args[0])
         result = func(*args[1:])
         if isinstance(result, (int, float, Decimal)):
-            return sass.SassNumber(result, type(result).__name__.encode())
+            return str(sass.SassNumber(result, type(result).__name__.encode()).value)
         return result
     except Exception as e:
         raise TemplateSyntaxError(str(e))

--- a/sass_processor/utils.py
+++ b/sass_processor/utils.py
@@ -34,9 +34,9 @@ def get_custom_functions():
             if not inspect.isfunction(func):
                 raise TemplateSyntaxError("{} is not a Python function".format(func))
             if six.PY2:
-                func_args = tuple(inspect.getargspec(func))
+                func_args = inspect.getargspec(func).args
             else:
-                func_args = inspect.getfullargspec(func)
+                func_args = inspect.getfullargspec(func).args
             sass_func = sass.SassFunction(name, func_args, func)
             get_custom_functions._custom_functions.add(sass_func)
     return get_custom_functions._custom_functions

--- a/sass_processor/utils.py
+++ b/sass_processor/utils.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from decimal import Decimal
 import inspect
 from django.conf import settings
 from django.template import TemplateSyntaxError
+from django.utils import six
 from django.utils.module_loading import import_string
 
 try:
@@ -26,13 +26,17 @@ def get_custom_functions():
     get_custom_functions._custom_functions = {sass.SassFunction('get-setting', ('key',), get_setting)}
     for name, func in getattr(settings, 'SASS_PROCESSOR_FUNCTIONS', {}).items():
         try:
-            if isinstance(func, str):
+            if isinstance(func, six.string_types):
                 func = import_string(func)
         except Exception as e:
             raise TemplateSyntaxError(str(e))
         else:
             if not inspect.isfunction(func):
-                raise TemplateSyntaxError("{} is not a Python function")
-            sass_func = sass.SassFunction(name, inspect.getfullargspec(func).args, func)
+                raise TemplateSyntaxError("{} is not a Python function".format(func))
+            if six.PY2:
+                func_args = inspect.getargspec(func)
+            else:
+                func_args = inspect.getfullargspec(func)
+            sass_func = sass.SassFunction(name, func_args, func)
             get_custom_functions._custom_functions.add(sass_func)
     return get_custom_functions._custom_functions

--- a/sass_processor/utils.py
+++ b/sass_processor/utils.py
@@ -1,10 +1,38 @@
 # -*- coding: utf-8 -*-
+from decimal import Decimal
 from django.conf import settings
 from django.template import TemplateSyntaxError
+from django.utils.module_loading import import_string
+
+try:
+    import sass
+except ImportError:
+    sass = None
 
 
-def get_setting(key):
+def get_setting(*args):
     try:
-        return getattr(settings, key)
+        return getattr(settings, args[0])
     except AttributeError as e:
         raise TemplateSyntaxError(e.message)
+
+
+def python_call(*args):
+    try:
+        func = import_string(args[0])
+        result = func(*args[1:])
+        if isinstance(result, (int, float, Decimal)):
+            return sass.SassNumber(result, type(result).__name__.encode())
+        return result
+    except Exception as e:
+        raise TemplateSyntaxError(str(e))
+
+
+# add a function to be used from inside SASS
+custom_functions = {
+    sass.SassFunction('get-setting', ('key',), get_setting),
+    sass.SassFunction('python-call0', ('callable',), python_call),
+    sass.SassFunction('python-call1', ('callable', 'a'), python_call),
+    sass.SassFunction('python-call2', ('callable', 'a', 'b'), python_call),
+    sass.SassFunction('python-call3', ('callable', 'a', 'b', 'c'), python_call),
+}

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ CLASSIFIERS = [
     'Framework :: Django :: 1.9',
     'Framework :: Django :: 1.10',
     'Framework :: Django :: 1.11',
+    'Framework :: Django :: 2.0',
 ]
 
 setup(
@@ -39,7 +40,9 @@ setup(
     author_email='jacob.rief@gmail.com',
     url='https://github.com/jrief/django-sass-processor',
     packages=find_packages(),
-    install_requires=[],
+    install_requires=[
+        'libsass>=0.13',
+    ],
     license='LICENSE-MIT',
     platforms=['OS Independent'],
     classifiers=CLASSIFIERS,

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,12 @@ setup(
     author_email='jacob.rief@gmail.com',
     url='https://github.com/jrief/django-sass-processor',
     packages=find_packages(),
-    install_requires=[
-        'libsass>=0.13',
-    ],
+    install_requires=[],
+    extras_require={
+        'dev': [
+            'libsass>=0.13',
+        ],
+    },
     license='LICENSE-MIT',
     platforms=['OS Independent'],
     classifiers=CLASSIFIERS,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+def get_width():
+    return 5
+
+def permutate(*args):
+    return args[2] + ' ' + args[0] + ' ' + args[1]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,10 @@
-def get_width():
-    return 5
+from sass_processor.types import SassNumber, SassColor
 
-def permutate(*args):
-    return args[2] + ' ' + args[0] + ' ' + args[1]
+def get_width():
+    return SassNumber(5)
+
+def get_margins(top, right, bottom, left):
+    return "{}px {}px {}px {}px".format(top.value, right.value, bottom.value, left.value)
+
+def get_plain_color(r, g, b):
+    return SassColor(r.value, g.value, b.value, 1)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -80,4 +80,10 @@ STATICFILES_DIRS = [
 
 SASS_PROCESSOR_ENABLED = True
 
+SASS_PROCESSOR_FUNCTIONS = {
+    'get-width': 'tests.get_width',
+    'get-margins': 'tests.get_margins',
+    'get-plain-color': 'tests.get_plain_color',
+}
+
 SASS_BLUE_COLOR = '#0000ff'

--- a/tests/static/tests/css/bluebox.scss
+++ b/tests/static/tests/css/bluebox.scss
@@ -1,3 +1,5 @@
 .bluebox {
 	background-color: get-setting(SASS_BLUE_COLOR);
+	width: python-call0('tests.get_width');
+	border: python-call3('tests.permutate', 'solid', 'red', '1px');
 }

--- a/tests/static/tests/css/bluebox.scss
+++ b/tests/static/tests/css/bluebox.scss
@@ -1,5 +1,5 @@
 .bluebox {
 	background-color: get-setting(SASS_BLUE_COLOR);
-	width: python-call0('tests.get_width');
-	border: python-call3('tests.permutate', 'solid', 'red', '1px');
+	margin: get-margins(10, 5, 20, 15);
+	color: get-plain-color(250, 10, 120);
 }

--- a/tests/test_sass_processor.py
+++ b/tests/test_sass_processor.py
@@ -85,7 +85,7 @@ class SassProcessorTest(TestCase):
         self.assertTrue(os.path.exists(css_file))
         with open(css_file, 'r') as f:
             output = f.read()
-        expected = '.bluebox{background-color:#0000ff;width:5.0;border:1px solid red}\n\n/*# sourceMappingURL=../../../../../../../../../static/tests/css/bluebox.css.map */'
+        expected = '.bluebox{background-color:#0000ff;margin:10.0px 5.0px 20.0px 15.0px;color:#fa0a78}\n\n/*# sourceMappingURL=../../../../../../../../../static/tests/css/bluebox.css.map */'
         self.assertEqual(expected, output)
 
     def assert_management_command(self, **kwargs):

--- a/tests/test_sass_processor.py
+++ b/tests/test_sass_processor.py
@@ -85,7 +85,7 @@ class SassProcessorTest(TestCase):
         self.assertTrue(os.path.exists(css_file))
         with open(css_file, 'r') as f:
             output = f.read()
-        expected = '.bluebox{background-color:#0000ff}\n\n/*# sourceMappingURL=../../../../../../../../../static/tests/css/bluebox.css.map */'
+        expected = '.bluebox{background-color:#0000ff;width:5.0;border:1px solid red}\n\n/*# sourceMappingURL=../../../../../../../../../static/tests/css/bluebox.css.map */'
         self.assertEqual(expected, output)
 
     def assert_management_command(self, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
-    libsass==0.14.2
-    pip==9.0.1
+    libsass
+    pip
     setuptools==35.0.1
     pytest==3.0.7
     pytest-django==3.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35}-django{20,19,110,111}
+envlist = py{27,34,35,36}-django{20,19,110,111}
 
 [testenv]
 deps =
@@ -7,7 +7,7 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
-    libsass==0.12.3
+    libsass==0.14.2
     pip==9.0.1
     setuptools==35.0.1
     pytest==3.0.7


### PR DESCRIPTION
This patch allows to call Python functions directly out of SCSS files.
More on this new feature can be found in the README.