### PR TITLE
source_map should have relative paths

### DIFF
--- a/sass_processor/processor.py
+++ b/sass_processor/processor.py
@@ -65,7 +65,8 @@ class SassProcessor(object):
         if not self.processor_enabled:
             return css_filename
         sourcemap_filename = css_filename + '.map'
-        if find_file(css_filename) and self.is_latest(sourcemap_filename, filename):
+        base = os.path.dirname(filename)
+        if find_file(css_filename) and self.is_latest(sourcemap_filename, base):
             return css_filename
 
         # with offline compilation, raise an error, if css file could not be found.
@@ -120,7 +121,7 @@ class SassProcessor(object):
         _, ext = os.path.splitext(self.resolve_path())
         return ext in self.sass_extensions
 
-    def is_latest(self, sourcemap_filename, filename):
+    def is_latest(self, sourcemap_filename, base):
         sourcemap_file = find_file(sourcemap_filename)
         if not sourcemap_file or not os.path.isfile(sourcemap_file):
             return False
@@ -128,7 +129,7 @@ class SassProcessor(object):
         with open(sourcemap_file, 'r') as fp:
             sourcemap = json.load(fp)
         for srcfilename in sourcemap.get('sources'):
-            srcfilename = os.path.join(os.path.dirname(filename), srcfilename)
+            srcfilename = os.path.join(base, srcfilename)
             if not os.path.isfile(srcfilename) or os.stat(srcfilename).st_mtime > sourcemap_mtime:
                 # at least one of the source is younger that the sourcemap referring it
                 return False

--- a/tests/test_sass_processor.py
+++ b/tests/test_sass_processor.py
@@ -39,7 +39,7 @@ class SassProcessorTest(TestCase):
         self.assertTrue(os.path.exists(css_file))
         with open(css_file, 'r') as f:
             output = f.read()
-        expected = "#main p{color:#00ff00;width:97%}#main p .redbox{background-color:#ff0000}#main p .redbox:hover{color:#000000}\n\n/*# sourceMappingURL=../../../../../../../../../static/tests/css/main.css.map */"
+        expected = "#main p{color:#00ff00;width:97%}#main p .redbox{background-color:#ff0000}#main p .redbox:hover{color:#000000}\n\n/*# sourceMappingURL=main.css.map */"
         self.assertEqual(expected, output)
 
         # check if compilation is skipped file for a second invocation of `sass_src`
@@ -85,7 +85,7 @@ class SassProcessorTest(TestCase):
         self.assertTrue(os.path.exists(css_file))
         with open(css_file, 'r') as f:
             output = f.read()
-        expected = '.bluebox{background-color:#0000ff;margin:10.0px 5.0px 20.0px 15.0px;color:#fa0a78}\n\n/*# sourceMappingURL=../../../../../../../../../static/tests/css/bluebox.css.map */'
+        expected = '.bluebox{background-color:#0000ff;margin:10.0px 5.0px 20.0px 15.0px;color:#fa0a78}\n\n/*# sourceMappingURL=bluebox.css.map */'
         self.assertEqual(expected, output)
 
     def assert_management_command(self, **kwargs):


### PR DESCRIPTION
prefix the source_map with the prefix of the source
to produce usable .map files.