### PR TITLE
setup.py: Specify encoding when loading README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,9 @@ from __future__ import unicode_literals
 
 from setuptools import setup, find_packages
 from sass_processor import __version__
+from io import open
 
-with open('README.md', 'r') as fh:
+with open('README.md', 'rt', encoding='utf-8') as fh:
     long_description = fh.read()
 
 CLASSIFIERS = [


### PR DESCRIPTION
This is important for linux servers that don't have a locale set, where python will default to "ascii" encoding.