### PR TITLE
Add argument to ignore template based on regexes

### DIFF
--- a/sass_processor/__init__.py
+++ b/sass_processor/__init__.py
@@ -18,6 +18,6 @@ Release logic:
 13. git push
 """
 
-__version__ = '0.8'
+__version__ = '0.8.1'
 
 default_app_config = 'sass_processor.apps.SassProcessorConfig'


### PR DESCRIPTION
Proposed solution for #135

Allows compilescss to selectively ignore some discovered templates.

Usage:
`python3 manage.py compilescss --ignore "django_otp/templates/.*admin19.*"`