### PR TITLE
Stop using FILE_CHARSET settings removed from Django

### DIFF
--- a/sass_processor/management/commands/compilescss.py
+++ b/sass_processor/management/commands/compilescss.py
@@ -117,10 +117,10 @@ class Command(BaseCommand):
         if engine == "jinja2":
             from compressor.offline.jinja2 import Jinja2Parser
             env = settings.COMPRESS_JINJA2_GET_ENVIRONMENT()
-            parser = Jinja2Parser(charset=settings.FILE_CHARSET, env=env)
+            parser = Jinja2Parser(charset="utf-8", env=env)
         elif engine == "django":
             from compressor.offline.django import DjangoParser
-            parser = DjangoParser(charset=settings.FILE_CHARSET)
+            parser = DjangoParser(charset="utf-8")
         else:
             raise CommandError(
                 "Invalid templating engine '{engine}' specified.".format(


### PR DESCRIPTION
Since Django 2.2 the FILE_CHARSET settings is deprecated and
starting with Django 3.1 all files must be UTF-8 encoded.

Fixes #138