### PR TITLE
Make tests work with pytest 4

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -85,3 +85,6 @@ SASS_PROCESSOR_CUSTOM_FUNCTIONS = {
 }
 
 SASS_BLUE_COLOR = '#0000ff'
+
+
+STATIC_ROOT = os.path.join(os.path.dirname(__file__), "tmpstatic")

--- a/tests/test_sass_processor.py
+++ b/tests/test_sass_processor.py
@@ -10,7 +10,6 @@ from django.template.loader import get_template
 from django.test import TestCase, override_settings
 
 
-@override_settings(STATIC_ROOT=py.test.ensuretemp('static').strpath)
 class SassProcessorTest(TestCase):
 
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ deps =
     libsass
     pip
     setuptools==35.0.1
-    pytest==3.0.7
-    pytest-django==3.1.2
+    pytest==4.6.11
+    pytest-django==3.5.1
     django111: django-compressor==2.3
     django20: django-compressor==2.3
     django21: django-compressor==2.3


### PR DESCRIPTION
pytest 4 does not `ensuretemp` anymore. one would need to use a session-scoped fixture, but just setting STATIC_ROOT in test.settings is simpler.