### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ python:
   - 3.7
   - 3.8
 
+arch:
+  - amd64
+  - ppc64le
+
 env:
   - DJANGOVER=django111
   - DJANGOVER=django20


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on Travis-CI in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The Travis-CI build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-sass-processor/builds/189054831

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj