### PR TITLE
Removed note about Django 3.0 compatibility from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,7 @@ third party services nor special IDE plugins.
 [![Downloads](https://img.shields.io/pypi/dm/django-sass-processor.svg)](https://pypi.python.org/pypi/django-sass-processor)
 [![Twitter Follow](https://img.shields.io/twitter/follow/shields_io.svg?style=social&label=Follow&maxAge=2592000)](https://twitter.com/jacobrief)
 
-**Version 0.7.5 will be the latest version to support Python-2.7** 
-
-The master branch of **django-sass-processor** already supports Django-3.0. However,
-[django-compressor](https://django-compressor.readthedocs.io/en/stable/) (which it depends on)
-[does not yet support Django-3.0](https://github.com/django-compressor/django-compressor/issues/980),
-hence I have to wait until a new version of django-compressor is available on PyPI.
-Until then, please use the master branch if you need Django-3.0.
-
+**Version 0.7.5 is the latest version to support Python-2.7** 
 
 ## Other good reasons for using this library
 


### PR DESCRIPTION
https://github.com/jrief/django-sass-processor/issues/144