### PR TITLE
Make arbitrary storages usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes for django-sass-processor
 
+- 1.0.0
+* Management command `compilescss` now uses the same storage as the template tags.
+* Any storage can now be used as destination.
+* Breaking change: The argument `--use-processor-root` to `compilescss` was replaced
+  with `--use-storage`.
+* Breaking change: `SassS3Boto3Storage` was removed. Use the `S3Boto3Storage` from
+  django-storages directly.
+
 - 0.8.2
 * Fixes: Management command `find_sources` does not ignore `SASS_PROCESSOR_AUTO_INCLUDE`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes for django-sass-processor
 
-- 1.0.0
+- 1.0.0.dev
 * Management command `compilescss` now uses the same storage as the template tags.
 * Any storage can now be used as destination.
 * Breaking change: The argument `--use-processor-root` to `compilescss` was replaced

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Jacob Rief
+Copyright (c) 2021 Dominik George <dominik.george@teckids.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Or you may compile results to the `SASS_PROCESSOR_ROOT` directory directy (if no
 `STATIC_ROOT`):
 
 ```shell
-./manage.py compilescss --use-processor-root
+./manage.py compilescss --use-storage
 ```
 
 Combine with `--delete-files` switch to purge results from there.
@@ -427,11 +427,31 @@ If it is set to `True`, instead of raising that exception, the compilation error
 to the Django logger.
 
 
-## Serving static files with S3
+## Using other storage backends for compiled CSS files
 
-A custom Storage class is provided for use if your deployment serves css files out of S3. You must have Boto 3 installed. To use it, add this to your settings file:
+Under the hood, SASS processor will use any storage configured in your settings as `STATICFILES_STORAGE`.
+This means you can use anything you normally use for serving static files, e.g. S3.
+
+A custom Storage class can be used if your deployment needs to serve generated CSS files from elsewhere,
+e.g. when your static files storage is not writable at runtime and you nede to re-compile CSS
+in production. To use a custom storage, configure it in `SASS_PROCESSOR_STORAGE`. You can also
+configure a dictionary with options that will be passed to the storage class as keyword arguments
+in `SASS_PROCESSOR_STORAGE_OPTIONS` (e.g. if you want to use `FileSystemStorage`, but with
+a different `location` or `base_url`:
+
 ```
-STATICFILES_STORAGE = 'sass_processor.storage.SassS3Boto3Storage'
+SASS_PROCESSOR_STORAGE = 'django.core.files.storage.FileSystemStorage'
+SASS_PROCESSOR_STORAGE_OPTIONS = {
+    'location': '/srv/media/generated',
+    'base_url': 'https://media.myapp.example.com/generated'
+}
+```
+
+Using the S3 storage backend from [django-storages](https://django-storages.readthedocs.io/en/latest/)
+with its regular configuration (if you do not otherwise use it for service static files):
+
+```
+SASS_PROCESSOR_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,6 @@ in the directory referred by `SASS_PROCESSOR_ROOT` (or, if unset `STATIC_ROOT`).
 your `settings.py`. If there is no `STATICFILES_FINDERS` in your `settings.py` don't forget
 to include the **Django** [default finders](https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-STATICFILES_FINDERS).
 
-If the directory referred by `SASS_PROCESSOR_ROOT` does not exist, then **django-sass-processor**
-creates it. This does not apply, if `SASS_PROCESSOR_ROOT` is unset and hence defaults to
-`STATIC_ROOT`. Therefore it is a good idea to otherwise use `SASS_PROCESSOR_ROOT = STATIC_ROOT`
-in your `settings.py`.
-
 ```python
 STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',

--- a/sass_processor/__init__.py
+++ b/sass_processor/__init__.py
@@ -18,6 +18,6 @@ Release logic:
 13. git push
 """
 
-__version__ = '0.8.2'
+__version__ = '1.0.0.dev0'
 
 default_app_config = 'sass_processor.apps.SassProcessorConfig'

--- a/sass_processor/apps.py
+++ b/sass_processor/apps.py
@@ -3,7 +3,6 @@ import os
 from django.apps import apps, AppConfig
 from django.conf import settings
 from django.contrib.staticfiles.finders import AppDirectoriesFinder
-from django.core.files.storage import get_storage_class
 
 
 APPS_INCLUDE_DIRS = []
@@ -11,7 +10,6 @@ APPS_INCLUDE_DIRS = []
 class SassProcessorConfig(AppConfig):
     name = 'sass_processor'
     verbose_name = "Sass Processor"
-    _storage = get_storage_class(import_path=settings.STATICFILES_STORAGE)()
     auto_include = getattr(settings, 'SASS_PROCESSOR_AUTO_INCLUDE', True)
     _pattern = re.compile(getattr(settings, 'SASS_PROCESSOR_INCLUDE_FILE_PATTERN', r'^_.+\.(scss|sass)$'))
 

--- a/sass_processor/finders.py
+++ b/sass_processor/finders.py
@@ -1,46 +1,18 @@
-import os
-from collections import OrderedDict
-from django.conf import settings
-from django.contrib.staticfiles.finders import FileSystemFinder
-from django.core.exceptions import ImproperlyConfigured
-from django.core.files.storage import FileSystemStorage
+from django.contrib.staticfiles.finders import BaseStorageFinder
+from .storage import SassFileStorage
 
 
-class CssFinder(FileSystemFinder):
+class CssFinder(BaseStorageFinder):
     """
     Find static *.css files compiled on the fly using templatetag `{% sass_src "" %}`
-    and stored below `SASS_PROCESSOR_ROOT`.
+    and stored in configured storage.
     """
-    locations = []
-
-    def __init__(self, apps=None, *args, **kwargs):
-        location = getattr(settings, 'SASS_PROCESSOR_ROOT', settings.STATIC_ROOT)
-        if not location:
-            msg = "Neither 'SASS_PROCESSOR_ROOT' nor 'STATIC_ROOT' has been declared in project settings."
-            raise ImproperlyConfigured(msg)
-        if not os.path.isdir(location):
-            try:
-                location = getattr(settings, 'SASS_PROCESSOR_ROOT')
-                os.makedirs(location)
-            except (AttributeError, OSError):
-                return
-        self.locations = [
-            ('', location),
-        ]
-        self.storages = OrderedDict()
-        filesystem_storage = FileSystemStorage(location=location)
-        filesystem_storage.prefix = self.locations[0][0]
-        self.storages[location] = filesystem_storage
-
-    def find(self, path, all=False):
-        if path.endswith('.css') or path.endswith('.css.map'):
-            return super().find(path, all)
-        return []
+    storage = SassFileStorage()
 
     def list(self, ignore_patterns):
         """
         Do not list the contents of the configured storages, since this has already been done by
-        the other finder of type FileSystemFinder.
+        other finders.
         This prevents the warning ``Found another file with the destination path ...``, while
         issuing ``./manage.py collectstatic``.
         """

--- a/tests/test_sass_processor.py
+++ b/tests/test_sass_processor.py
@@ -88,7 +88,7 @@ class SassProcessorTest(TestCase):
             'compilescss',
             **kwargs
         )
-        if kwargs.get('use_processor_root', False):
+        if kwargs.get('use_storage', False):
             css_file = os.path.join(settings.STATIC_ROOT, 'tests/css/main.css')
         else:
             css_file = os.path.join(settings.PROJECT_ROOT, 'static/tests/css/main.css')
@@ -98,7 +98,7 @@ class SassProcessorTest(TestCase):
         self.assertEqual(expected, output)
         self.assertFalse(os.path.exists(css_file + '.map'))
 
-        if not kwargs.get('use_processor_root', False):
+        if not kwargs.get('use_storage', False):
             call_command('compilescss', delete_files=True)
             self.assertFalse(os.path.exists(css_file))
 
@@ -121,22 +121,22 @@ class SassProcessorTest(TestCase):
         )
 
     @override_settings(DEBUG=False)
-    def test_use_processor_root_django(self):
+    def test_use_storage_django(self):
         self.assert_management_command(
             engine='django',
-            use_processor_root=True
+            use_storage=True
         )
 
     @override_settings(DEBUG=False)
-    def test_use_processor_root_jinja2(self):
+    def test_use_storage_jinja2(self):
         self.assert_management_command(
             engine='jinja2',
-            use_processor_root=True
+            use_storage=True
         )
 
     @override_settings(DEBUG=False)
-    def test_use_processor_root_multiple(self):
+    def test_use_storage_multiple(self):
         self.assert_management_command(
             engine=['jinja2', 'django'],
-            use_processor_root=True
+            use_storage=True
         )


### PR DESCRIPTION
This PR generalises the configuration and use of the storage compiled files are saved to.

Mainly, there were a few places that did not consequently use the storage class:

* `--delete-files` in `compilescss` used `os.remove` instead of the storage
* `save_to_destination` in `compilescss` did not delete a pre-existing file (thus causing the storage to use a random name on second compilation)
* The finder always scanned the filesystem directly
* The returned URL could only use the `staticfiles` system, which was somewhat independent of the rest because normally, `STATIC_URL` would be set correctly even with a remote storage like S3. My special use-case, as laid out in #146, is however a read-only `STATIC_ROOT`. The changes all taken together allow just using the default file storage. As the storage defaults to `STATICFILES_STORAGE`, we can just use the storage's URL method here directly, and it will work for all other cases as well. I tested with the default `STATICFILES_STORAGE`, `DEFAULT_FILE_STORAGE`, and a separate S3 storage.

I did a bit of refactoring/minor bugfixing on the go because I found inconsistencies when reading and understanding the code:

* `_storage` in the `AppConfig` was never used, so I removed it
* `use_processor_root` and `use_static_root` have been aligend into `use_storage` (because that is strictly what it does now)
* `SassBoto3Storage` was, IMHO, wrong — Amazon is not the only S3 provider, and the S3 backend from django-storages can be used for any S3 provider. Overriding the `base_url` is thus wrong. I removed it in favour of just using the `S3Boto3Storage` directly — it wil leither use the settings forthis backend, or can be passed different options using the `SASS_PROCESSOR_STORAGE_OPTIONS` setting

The test suite continues to run fine.

Some remarks are in the commits where I considered it useful to have a rationale in the history.

Closes #146