### PR TITLE
Updates testing instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,11 +480,12 @@ buildpack to automatically compile scss for you.
 
 ## Development
 
-To run the tests locally, clone the repository, create a new virtualenv, activate it and then run
+To run the tests locally, clone the repository, and, in your local copy, create a new virtualenv.
 these commands:
 
 ```shell
-cd django-sass-processor
-pip install tox
-tox
+python -m pip install --upgrade pip
+pip install Django
+pip install -r tests/requirements.txt
+python -m pytest tests
 ```


### PR DESCRIPTION
It looks like Tox has been removes, and pytest is the working test runner. I changed the phrasing slightly on the install instructions for a more specific order of operations on creating the virtualenv as well.