### PR TITLE
Fixes `default_app_config` Django deprecation warning

### DIFF
--- a/sass_processor/__init__.py
+++ b/sass_processor/__init__.py
@@ -22,5 +22,6 @@ __version__ = '1.1'
 
 import django
 
-if django.VERSION < (4, 0):
+if django.VERSION < (3, 2):
+    # https://docs.djangoproject.com/en/dev/releases/3.2/#whats-new-3-2
     default_app_config = 'sass_processor.apps.SassProcessorConfig'

--- a/sass_processor/__init__.py
+++ b/sass_processor/__init__.py
@@ -20,4 +20,7 @@ Release logic:
 
 __version__ = '1.1'
 
-default_app_config = 'sass_processor.apps.SassProcessorConfig'
+import django
+
+if django.VERSION < (4, 0):
+    default_app_config = 'sass_processor.apps.SassProcessorConfig'


### PR DESCRIPTION
Since [Django 3.2](https://docs.djangoproject.com/en/dev/releases/3.2/#whats-new-3-2), `default_app_config` has been unnecessary and now produces a deprecation warning since it'll be removed as an option in 4.1.

This PR makes setting `default_app_config` dependent on the Django version.