### PR TITLE
Manifest files storage

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Jacob Rief
+Copyright (c) 2015-2023 Jacob Rief <jacob.rief@gmail.com>
 Copyright (c) 2021 Dominik George <dominik.george@teckids.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/sass_processor/processor.py
+++ b/sass_processor/processor.py
@@ -6,6 +6,7 @@ import subprocess
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
+from django.core.files.storage import get_storage_class
 from django.template import Context
 from django.utils.encoding import force_bytes
 
@@ -24,6 +25,7 @@ logger = logging.getLogger('sass-processor')
 
 class SassProcessor:
     source_storage = SassFileStorage()
+    delivery_storage = get_storage_class(settings.STATICFILES_STORAGE)()
     include_paths = [str(ip) for ip in getattr(settings, 'SASS_PROCESSOR_INCLUDE_DIRS', [])]
     try:
         sass_precision = int(settings.SASS_PRECISION)
@@ -140,7 +142,10 @@ class SassProcessor:
 
     @classmethod
     def handle_simple(cls, path):
-        return cls.source_storage.url(path)
+        try:
+            return cls.delivery_storage.url(path)
+        except ValueError:
+            return cls.source_storage.url(path)
 
 
 _sass_processor = SassProcessor()

--- a/sass_processor/storage.py
+++ b/sass_processor/storage.py
@@ -16,6 +16,9 @@ class SassFileStorage(LazyObject):
 
         self._wrapped = storage_class(**storage_options)
 
+    def __repr__(self):
+        return repr(self._wrapped)
+
 
 def find_file(path):
     for finder in get_finders():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = django-sass-processor
-version = attr: sass_processor.__version__
 description = SASS processor to compile SCSS files into *.css, while rendering, or offline.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
+from sass_processor import __version__
 
-setup()
+setup(
+    version=__version__,
+)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from tests.jinja2 import environment
 
@@ -12,6 +12,8 @@ DATABASES = {
         'NAME': ':memory:',
     }
 }
+
+PROJECT_ROOT = Path(__file__).parent
 
 INSTALLED_APPS = [
     'django.contrib.contenttypes',
@@ -64,8 +66,6 @@ SECRET_KEY = 'secret'
 
 STATIC_URL = '/static/'
 
-PROJECT_ROOT = os.path.abspath(os.path.join(__file__, os.path.pardir))
-
 STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
@@ -73,8 +73,10 @@ STATICFILES_FINDERS = [
 ]
 
 STATICFILES_DIRS = [
-    os.path.join(PROJECT_ROOT, 'static'),
+    PROJECT_ROOT / 'static',
 ]
+
+STATIC_ROOT = PROJECT_ROOT / 'tmpstatic'
 
 SASS_PROCESSOR_ENABLED = True
 
@@ -85,6 +87,3 @@ SASS_PROCESSOR_CUSTOM_FUNCTIONS = {
 }
 
 SASS_BLUE_COLOR = '#0000ff'
-
-
-STATIC_ROOT = os.path.join(os.path.dirname(__file__), "tmpstatic")

--- a/tests/test_sass_processor.py
+++ b/tests/test_sass_processor.py
@@ -28,30 +28,30 @@ class SassProcessorTest(TestCase):
         )
         # Strip the line breaks.
         template_content = template.render({}).strip()
-        self.assertEqual('/static/tests/css/main.css', template_content)
+        assert template_content == '/static/tests/css/main.css'
 
-        css_file = os.path.join(settings.STATIC_ROOT, 'tests/css/main.css')
-        self.assertTrue(os.path.exists(css_file))
-        with open(css_file, 'r') as f:
+        css_file = settings.STATIC_ROOT / 'tests/css/main.css'
+        assert css_file.exists()
+        with css_file.open('r') as f:
             output = f.read()
         expected = "#main p{color:#00ff00;width:97%}#main p .redbox{background-color:#ff0000}#main p .redbox:hover{color:#000000}\n\n/*# sourceMappingURL=main.css.map */"
-        self.assertEqual(expected, output)
+        assert expected == output
 
         # check if compilation is skipped file for a second invocation of `sass_src`
-        timestamp = os.path.getmtime(css_file)
+        timestamp = css_file.stat().st_mtime
         template.render({})
-        self.assertEqual(timestamp, os.path.getmtime(css_file))
+        assert timestamp == css_file.stat().st_mtime
 
         # removing `main.css.map` should trigger a recompilation
-        os.remove(css_file + '.map')
+        css_file.with_suffix(css_file.suffix + '.map').unlink()
         template.render({})
-        self.assertTrue(os.path.exists(css_file + '.map'))
+        assert css_file.with_suffix(css_file.suffix + '.map').exists()
 
         # if `main.scss` is newer than `main.css`, recompile everything
         longago = calendar.timegm(datetime(2017, 1, 1).timetuple())
         os.utime(css_file, (longago, longago))
         template.render({})
-        self.assertGreater(timestamp, os.path.getmtime(css_file))
+        assert timestamp > css_file.stat().st_mtime
 
     def test_sass_src_django(self):
         self.assert_sass_src_engine(
@@ -76,12 +76,12 @@ class SassProcessorTest(TestCase):
 
         css_file = sass_processor('tests/css/bluebox.scss')
         self.assertEqual('/static/tests/css/bluebox.css', css_file)
-        css_file = os.path.join(settings.STATIC_ROOT, 'tests/css/bluebox.css')
-        self.assertTrue(os.path.exists(css_file))
-        with open(css_file, 'r') as f:
+        css_file = settings.STATIC_ROOT / 'tests/css/bluebox.css'
+        assert css_file.exists()
+        with css_file.open('r') as f:
             output = f.read()
         expected = '.bluebox{background-color:#0000ff;margin:10.0px 5.0px 20.0px 15.0px;color:#fa0a78}\n\n/*# sourceMappingURL=bluebox.css.map */'
-        self.assertEqual(expected, output)
+        assert expected == output
 
     def assert_management_command(self, **kwargs):
         call_command(
@@ -89,18 +89,18 @@ class SassProcessorTest(TestCase):
             **kwargs
         )
         if kwargs.get('use_storage', False):
-            css_file = os.path.join(settings.STATIC_ROOT, 'tests/css/main.css')
+            css_file = settings.STATIC_ROOT / 'tests/css/main.css'
         else:
-            css_file = os.path.join(settings.PROJECT_ROOT, 'static/tests/css/main.css')
-        with open(css_file, 'r') as f:
+            css_file = settings.PROJECT_ROOT / 'static/tests/css/main.css'
+        with css_file.open('r') as f:
             output = f.read()
         expected = '#main p{color:#00ff00;width:97%}#main p .redbox{background-color:#ff0000}#main p .redbox:hover{color:#000000}\n'
-        self.assertEqual(expected, output)
-        self.assertFalse(os.path.exists(css_file + '.map'))
+        assert expected == output
+        assert not css_file.with_suffix(css_file.suffix + '.map').exists()
 
         if not kwargs.get('use_storage', False):
             call_command('compilescss', delete_files=True)
-            self.assertFalse(os.path.exists(css_file))
+            assert not css_file.exists()
 
     @override_settings(DEBUG=False)
     def test_management_command_django(self):


### PR DESCRIPTION
This branch is based on version 1.2.1 which is able to handle the manifest static files storage properly.

* A unit test to check if the former works has been added.
* All unit tests now use `pathlib.Path` instead of `os.path...`.