### PR TITLE
Update compatibility claims and testing matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: ["3.9"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,24 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        django-version: ["3.2", "4.0", "4.1", "4.2"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        django-version: ["3.2", "4.2", "5.0"]
         exclude:
+          - python-version: 3.11
+            django-version: 3.2
+          - python-version: 3.12
+            django-version: 3.2
+          - python-version: 3.8
+            django-version: 5.0
           - python-version: 3.9
-            django-version: 2.2
-          - python-version: 3.10
-            django-version: 2.2
-          - python-version: 3.7
-            django-version: 4.0
-          - python-version: 3.7
-            django-version: 4.1
-          - python-version: 3.7
-            django-version: 4.2
+            django-version: 5.0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,14 +19,14 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Framework :: Django :: 3.2
-    Framework :: Django :: 4.0
-    Framework :: Django :: 4.1
     Framework :: Django :: 4.2
+    Framework :: Django :: 5.0
 
 [options]
 packages = find:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 libsass
 pytest
 pytest-django


### PR DESCRIPTION
to remove eol'd versions of python and django and include python 3.11,3.12 and django 5.0.