### PR TITLE
Fix compatibility with Django 5.1

### DIFF
--- a/sass_processor/storage.py
+++ b/sass_processor/storage.py
@@ -1,7 +1,7 @@
 from django import VERSION
 from django.conf import settings
 from django.contrib.staticfiles.finders import get_finders
-from django.core.files.storage import FileSystemStorage, get_storage_class
+from django.core.files.storage import FileSystemStorage
 from django.utils.functional import LazyObject
 from django.utils.module_loading import import_string
 
@@ -17,6 +17,7 @@ class SassFileStorage(LazyObject):
             storage_options = sass_processor_storage.get("OPTIONS") or {}
             storage_class = import_string(storage_path)
         else:
+            from django.core.files.storage import get_storage_class
             staticfiles_storage_backend = settings.STATICFILES_STORAGE
             storage_path = getattr(settings, 'SASS_PROCESSOR_STORAGE', staticfiles_storage_backend)
             storage_options = getattr(settings, 'SASS_PROCESSOR_STORAGE_OPTIONS', {})


### PR DESCRIPTION
Do not import get_storage_class() which is deprecated since Django 4.2. 20483483 stopped using it on recent Django version but did not remove the import so sass_processor stopped working on the upcoming Django 5.1 which removes the get_storage_class() function.