### PR TITLE
Fix for usage with custom storage configs that have options

### DIFF
--- a/sass_processor/storage.py
+++ b/sass_processor/storage.py
@@ -10,11 +10,13 @@ class SassFileStorage(LazyObject):
     def _setup(self):
         version_parts = VERSION[:2]
         if version_parts[0] > 4 or (version_parts[0] == 4 and version_parts[1] >= 2):
-            staticfiles_storage_backend = settings.STORAGES.get("staticfiles", {}).get("BACKEND")
-            sass_processor_storage = settings.STORAGES.get("sass_processor", {})
+            if "sass_processor" in settings.STORAGES:
+                storage_config = settings.STORAGES.get("sass_processor", {})
+            else:
+                storage_config = settings.STORAGES.get("staticfiles", {})
 
-            storage_path = sass_processor_storage.get("BACKEND") or staticfiles_storage_backend
-            storage_options = sass_processor_storage.get("OPTIONS") or {}
+            storage_path = storage_config.get("BACKEND")
+            storage_options = storage_config.get("OPTIONS")
             storage_class = import_string(storage_path)
         else:
             from django.core.files.storage import get_storage_class


### PR DESCRIPTION
Hello, I am in a project that is using this with a custom storage config, and the current code pulls in the custom `BACKEND`, but throws away the `OPTIONS` key from the config, which breaks the config, since the storage doesn't work properly without its options.

This PR remedies that by simply using the `sass_processor` config if it exists (as with the current code), and falls back to the custom config if _it_ exists, without overwriting the `OPTIONS` with `{}`.