### PR TITLE
Add support for Python 3.13 and Django 5.1/5.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,17 +12,31 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        django-version: ["3.2", "4.2", "5.0"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        django-version: ["3.2", "4.2", "5.0", "5.1", "5.2"]
         exclude:
           - python-version: 3.11
             django-version: 3.2
           - python-version: 3.12
             django-version: 3.2
+          - python-version: 3.13
+            django-version: 3.2
+          - python-version: 3.13
+            django-version: 4.2
+          - python-version: 3.13
+            django-version: 5.0
           - python-version: 3.8
             django-version: 5.0
           - python-version: 3.9
             django-version: 5.0
+          - python-version: 3.8
+            django-version: 5.1
+          - python-version: 3.9
+            django-version: 5.1
+          - python-version: 3.8
+            django-version: 5.2
+          - python-version: 3.9
+            django-version: 5.2
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request adds support for the Python 3.13 and the latest Django versions (5.1 and 5.2).

- Updated test configurations to include Python 3.13
- Updated test configurations to include versions 5.1 and 5.2

No breaking changes were introduced, and existing compatibility is preserved.

Let me know if you would like this split into multiple PRs or tested in additional environments.
