### PR TITLE
Fix incorrect handling of the ROOT setting in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ in `STORAGES['sass_processor']['OPTIONS']` [Django >= 4.2.*] or `SASS_PROCESSOR_
 ```python
 # For Django >= 4.2.*
 STORAGES['sass_processor'] = {
-    'BACKEND': 'django.core.files.storage.FileSystemStorage',
+    'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
     'OPTIONS': {
         'location': '/srv/media/generated',
         'base_url': 'https://media.myapp.example.com/generated'

--- a/sass_processor/storage.py
+++ b/sass_processor/storage.py
@@ -1,3 +1,5 @@
+import copy
+
 from django import VERSION
 from django.conf import settings
 from django.contrib.staticfiles.finders import get_finders
@@ -10,12 +12,14 @@ class SassFileStorage(LazyObject):
     def _setup(self):
         version_parts = VERSION[:2]
         if version_parts[0] > 4 or (version_parts[0] == 4 and version_parts[1] >= 2):
-            staticfiles_storage_backend = settings.STORAGES.get("staticfiles", {}).get("BACKEND")
-            sass_processor_storage = settings.STORAGES.get("sass_processor", {})
+            staticfiles_storage_backend = settings.STORAGES.get('staticfiles', {}).get('BACKEND')
+            sass_processor_storage = settings.STORAGES.get('sass_processor', {})
 
-            storage_path = sass_processor_storage.get("BACKEND") or staticfiles_storage_backend
-            storage_options = sass_processor_storage.get("OPTIONS") or {}
+            storage_path = sass_processor_storage.get('BACKEND') or staticfiles_storage_backend
+            storage_options = copy.deepcopy(sass_processor_storage.get('OPTIONS') or {})
             storage_class = import_string(storage_path)
+
+            storage_options['ROOT'] = sass_processor_storage.get('ROOT') or settings.STATIC_ROOT
         else:
             from django.core.files.storage import get_storage_class
             staticfiles_storage_backend = settings.STATICFILES_STORAGE
@@ -23,10 +27,10 @@ class SassFileStorage(LazyObject):
             storage_options = getattr(settings, 'SASS_PROCESSOR_STORAGE_OPTIONS', {})
             storage_class = get_storage_class(storage_path)
 
-            storage_options["ROOT"] = getattr(settings, 'SASS_PROCESSOR_ROOT', settings.STATIC_ROOT)
+            storage_options['ROOT'] = getattr(settings, 'SASS_PROCESSOR_ROOT', settings.STATIC_ROOT)
 
         if storage_path == staticfiles_storage_backend and issubclass(storage_class, FileSystemStorage):
-            storage_options['location'] = storage_options.pop("ROOT", None) or settings.STATIC_ROOT
+            storage_options['location'] = storage_options.pop('ROOT', None) or settings.STATIC_ROOT
             storage_options['base_url'] = settings.STATIC_URL
 
         self._wrapped = storage_class(**storage_options)


### PR DESCRIPTION
This pull request fixes an issue where the ROOT setting was not being properly read from the configuration.
Due to this, the behavior relying on ROOT did not function as expected in some environments.

Changes made:
Ensured that the ROOT setting is retrieved correctly using getattr with a proper fallback.

Please let me know if any additional changes are needed. Thank you for maintaining this project.